### PR TITLE
Cleanup tests

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -81,13 +81,13 @@ func (l *Lexer) Read() (tok token.Token, err error) {
 		return
 	}
 
-	err = l.readIdent()
+	l.readIdent()
 	tok.Keyword = l.keywordFromIdent(inputPositionStart, l.inputPosition)
 	tok.SetEnd(l.inputPosition, l.textPosition)
 	return
 }
 
-func (l *Lexer) swallowWhitespace() (err error) {
+func (l *Lexer) swallowWhitespace() {
 
 	var next byte
 
@@ -95,11 +95,11 @@ func (l *Lexer) swallowWhitespace() (err error) {
 		next = l.peekRune()
 
 		if next == runes.EOF {
-			return nil
+			return
 		}
 
 		if !l.byteIsWhitespace(next) {
-			return nil
+			return
 		}
 
 		l.readRune()
@@ -107,79 +107,73 @@ func (l *Lexer) swallowWhitespace() (err error) {
 }
 
 // Peek will emit the next keyword without advancing the reader position
-func (l *Lexer) Peek(ignoreWhitespace bool) (key keyword.Keyword, err error) {
+func (l *Lexer) Peek(ignoreWhitespace bool) keyword.Keyword {
 
 	if ignoreWhitespace {
-		err = l.swallowWhitespace()
-		if err != nil {
-			return key, err
-		}
+		l.swallowWhitespace()
 	}
 
 	next := l.peekRune()
-	if err != nil {
-		return key, err
-	}
 
 	return l.keywordFromRune(next)
 }
 
-func (l *Lexer) keywordFromRune(r byte) (key keyword.Keyword, err error) {
+func (l *Lexer) keywordFromRune(r byte) keyword.Keyword {
 
 	switch r {
 	case runes.EOF:
-		return keyword.EOF, nil
+		return keyword.EOF
 	case runes.SPACE:
-		return keyword.SPACE, nil
+		return keyword.SPACE
 	case runes.TAB:
-		return keyword.TAB, nil
+		return keyword.TAB
 	case runes.COMMA:
-		return keyword.COMMA, nil
+		return keyword.COMMA
 	case runes.LINETERMINATOR:
-		return runes.LINETERMINATOR, nil
+		return keyword.LINETERMINATOR
 	case runes.QUOTE:
-		return keyword.STRING, nil
+		return keyword.STRING
 	case runes.DOLLAR:
-		return keyword.VARIABLE, nil
+		return keyword.VARIABLE
 	case runes.PIPE:
-		return keyword.PIPE, nil
+		return keyword.PIPE
 	case runes.EQUALS:
-		return keyword.EQUALS, nil
+		return keyword.EQUALS
 	case runes.AT:
-		return keyword.AT, nil
+		return keyword.AT
 	case runes.COLON:
-		return keyword.COLON, nil
+		return keyword.COLON
 	case runes.BANG:
-		return keyword.BANG, nil
+		return keyword.BANG
 	case runes.BRACKETOPEN:
-		return keyword.BRACKETOPEN, nil
+		return keyword.BRACKETOPEN
 	case runes.BRACKETCLOSE:
-		return keyword.BRACKETCLOSE, nil
+		return keyword.BRACKETCLOSE
 	case runes.CURLYBRACKETOPEN:
-		return keyword.CURLYBRACKETOPEN, nil
+		return keyword.CURLYBRACKETOPEN
 	case runes.CURLYBRACKETCLOSE:
-		return keyword.CURLYBRACKETCLOSE, nil
+		return keyword.CURLYBRACKETCLOSE
 	case runes.SQUAREBRACKETOPEN:
-		return keyword.SQUAREBRACKETOPEN, nil
+		return keyword.SQUAREBRACKETOPEN
 	case runes.SQUAREBRACKETCLOSE:
-		return keyword.SQUAREBRACKETCLOSE, nil
+		return keyword.SQUAREBRACKETCLOSE
 	case runes.AND:
-		return keyword.AND, nil
+		return keyword.AND
 	case runes.DOT:
 		if l.peekEquals(runes.DOT, runes.DOT, runes.DOT) {
-			return keyword.SPREAD, nil
+			return keyword.SPREAD
 		}
-		return key, fmt.Errorf("keywordFromRune: must be '...'")
+		return keyword.DOT
 	}
 
 	if runeIsDigit(r) {
 		if l.peekIsFloat() {
-			return keyword.FLOAT, nil
+			return keyword.FLOAT
 		}
-		return keyword.INTEGER, nil
+		return keyword.INTEGER
 	}
 
-	return l.peekIdent(), nil
+	return l.peekIdent()
 }
 
 func (l *Lexer) peekIsFloat() (isFloat bool) {
@@ -191,9 +185,7 @@ func (l *Lexer) peekIsFloat() (isFloat bool) {
 
 		peeked = l.input[i]
 
-		if peeked == runes.EOF {
-			return hasDot
-		} else if l.byteIsWhitespace(peeked) {
+		if l.byteIsWhitespace(peeked) {
 			return hasDot
 		} else if peeked == runes.DOT && !hasDot {
 			hasDot = true
@@ -245,7 +237,7 @@ func (l *Lexer) matchSingleRuneToken(r byte, tok *token.Token) bool {
 	return true
 }
 
-func (l *Lexer) readIdent() error {
+func (l *Lexer) readIdent() {
 
 	var r byte
 
@@ -253,9 +245,9 @@ func (l *Lexer) readIdent() error {
 		r = l.readRune()
 		if !runeIsIdent(r) {
 			if r != runes.EOF {
-				return l.unreadRune()
+				l.unreadRune()
 			}
-			return nil
+			return
 		}
 	}
 }
@@ -360,10 +352,7 @@ func (l *Lexer) readVariable(tok *token.Token) error {
 
 	tok.Keyword = keyword.VARIABLE
 
-	peeked, err := l.Peek(false)
-	if err != nil {
-		return err
-	}
+	peeked := l.Peek(false)
 
 	if peeked == keyword.SPACE ||
 		peeked == keyword.TAB ||
@@ -372,10 +361,7 @@ func (l *Lexer) readVariable(tok *token.Token) error {
 		return fmt.Errorf("readVariable: must not have whitespace after $")
 	}
 
-	err = l.readIdent()
-	if err != nil {
-		return err
-	}
+	l.readIdent()
 
 	tok.SetEnd(l.inputPosition, l.textPosition)
 	tok.TextPosition.CharStart -= 1
@@ -453,10 +439,7 @@ func (l *Lexer) readDigit(tok *token.Token) error {
 	}
 
 	if r != runes.EOF {
-		err := l.unreadRune()
-		if err != nil {
-			return err
-		}
+		l.unreadRune()
 	}
 
 	tok.Keyword = keyword.INTEGER
@@ -483,10 +466,7 @@ func (l *Lexer) readFloat(tok *token.Token) error {
 	}
 
 	if r != runes.EOF {
-		err := l.unreadRune()
-		if err != nil {
-			return err
-		}
+		l.unreadRune()
 	}
 
 	tok.Keyword = keyword.FLOAT
@@ -515,11 +495,7 @@ func (l *Lexer) readRune() (r byte) {
 	return
 }
 
-func (l *Lexer) unreadRune() error {
-
-	if l.inputPosition == 0 {
-		return fmt.Errorf("unreadRune: cannot unread from inputPosition 0")
-	}
+func (l *Lexer) unreadRune() {
 
 	l.inputPosition--
 
@@ -529,8 +505,6 @@ func (l *Lexer) unreadRune() error {
 	} else {
 		l.textPosition.CharStart--
 	}
-
-	return nil
 }
 
 func (l *Lexer) peekRune() (r byte) {
@@ -599,6 +573,7 @@ func (l *Lexer) readMultiLineString(tok *token.Token) error {
 
 				if !isMultiLineStringEnd {
 					escaped = false
+					l.readRune()
 				} else {
 					tok.SetEnd(l.inputPosition, l.textPosition)
 					tok.TextPosition.CharStart -= 3

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -25,12 +25,9 @@ func TestLexer_Peek_Read(t *testing.T) {
 		}
 	}
 
-	mustPeek := func(k keyword.Keyword) checkFunc {
+	mustPeek := func(k keyword.Keyword, ignoreWhitespace bool) checkFunc {
 		return func(lex *Lexer, i int) {
-			peeked, err := lex.Peek(true)
-			if err != nil {
-				panic(err)
-			}
+			peeked := lex.Peek(ignoreWhitespace)
 			if peeked != k {
 				panic(fmt.Errorf("mustPeek: want: %s, got: %s [check: %d]", k.String(), peeked.String(), i))
 			}
@@ -55,7 +52,7 @@ func TestLexer_Peek_Read(t *testing.T) {
 
 	mustPeekAndRead := func(k keyword.Keyword, literal string) checkFunc {
 		return func(lex *Lexer, i int) {
-			mustPeek(k)(lex, i)
+			mustPeek(k, true)(lex, i)
 			mustRead(k, literal)(lex, i)
 		}
 	}
@@ -99,6 +96,12 @@ func TestLexer_Peek_Read(t *testing.T) {
 		}
 	}
 
+	t.Run("set too large input", func(t *testing.T) {
+		lex := NewLexer()
+		if err := lex.SetInput(make([]byte, 65536)); err == nil {
+			panic(fmt.Errorf("must err on too large input"))
+		}
+	})
 	t.Run("read correct when resetting input", func(t *testing.T) {
 		run("x",
 			mustRead(keyword.IDENT, "x"),
@@ -112,6 +115,28 @@ func TestLexer_Peek_Read(t *testing.T) {
 			mustRead(keyword.EOF, ""),
 			mustRead(keyword.EOF, ""),
 		)
+	})
+	t.Run("peek space", func(t *testing.T) {
+		run(" ", mustPeek(keyword.SPACE, false))
+	})
+	t.Run("peek tab", func(t *testing.T) {
+		run("\t", mustPeek(keyword.TAB, false))
+	})
+	t.Run("peek tab 2", func(t *testing.T) {
+		run("	", mustPeek(keyword.TAB, false))
+	})
+	t.Run("peek comma", func(t *testing.T) {
+		run(",", mustPeek(keyword.COMMA, false))
+	})
+	t.Run("peek line terminator", func(t *testing.T) {
+		run("\n", mustPeek(keyword.LINETERMINATOR, false))
+	})
+	t.Run("peek line terminator 2", func(t *testing.T) {
+		run(`
+`, mustPeek(keyword.LINETERMINATOR, false))
+	})
+	t.Run("peek dot", func(t *testing.T) {
+		run(".. ", mustPeek(keyword.DOT, false))
 	})
 	t.Run("read integer", func(t *testing.T) {
 		run("1337", mustPeekAndRead(keyword.INTEGER, "1337"))
@@ -134,6 +159,12 @@ func TestLexer_Peek_Read(t *testing.T) {
 	t.Run("read float with comma", func(t *testing.T) {
 		run("13.37,", mustPeekAndRead(keyword.FLOAT, "13.37"))
 	})
+	t.Run("peek invalid float as integer", func(t *testing.T) {
+		run("1.3.3", mustPeek(keyword.INTEGER, true))
+	})
+	t.Run("peek invalid float as integer 2", func(t *testing.T) {
+		run("1.3x", mustPeek(keyword.INTEGER, true))
+	})
 	t.Run("fail reading incomplete float", func(t *testing.T) {
 		run("13.", mustErrRead())
 	})
@@ -143,11 +174,20 @@ func TestLexer_Peek_Read(t *testing.T) {
 	t.Run("read single line string with escaped quote", func(t *testing.T) {
 		run("\"foo \\\" bar\"", mustPeekAndRead(keyword.STRING, "foo \\\" bar"))
 	})
+	t.Run("read single line string with escaped backslash", func(t *testing.T) {
+		run("\"foo \\\\ bar\"", mustPeekAndRead(keyword.STRING, "foo \\\\ bar"))
+	})
 	t.Run("read multi line string with escaped quote", func(t *testing.T) {
 		run("\"\"\"foo \\\" bar\"\"\"", mustPeekAndRead(keyword.STRING, "foo \\\" bar"))
 	})
+	t.Run("read multi line string with two escaped quotes", func(t *testing.T) {
+		run("\"\"\"foo \"\" bar\"\"\"", mustPeekAndRead(keyword.STRING, "foo \"\" bar"))
+	})
 	t.Run("read multi line string", func(t *testing.T) {
 		run("\"\"\"\nfoo\nbar\"\"\"", mustPeekAndRead(keyword.STRING, "\nfoo\nbar"))
+	})
+	t.Run("read multi line string with escaped backslash", func(t *testing.T) {
+		run("\"\"\"foo \\\\ bar\"\"\"", mustPeekAndRead(keyword.STRING, "foo \\\\ bar"))
 	})
 	t.Run("read pipe", func(t *testing.T) {
 		run("|", mustPeekAndRead(keyword.PIPE, "|"))
@@ -220,6 +260,9 @@ func TestLexer_Peek_Read(t *testing.T) {
 	})
 	t.Run("read ident with colon", func(t *testing.T) {
 		run("foo:", mustPeekAndRead(keyword.IDENT, "foo"))
+	})
+	t.Run("read ident with negative sign", func(t *testing.T) {
+		run("foo-bar", mustPeekAndRead(keyword.IDENT, "foo-bar"))
 	})
 	t.Run("read true", func(t *testing.T) {
 		run("true", mustPeekAndRead(keyword.TRUE, "true"))
@@ -512,13 +555,9 @@ func BenchmarkLexer(b *testing.B) {
 		}
 
 		var key keyword.Keyword
-		var err error
 
 		for key != keyword.EOF {
-			key, err = lexer.Peek(true)
-			if err != nil {
-				b.Fatal(err)
-			}
+			key = lexer.Peek(true)
 
 			tok, err := lexer.Read()
 			if err != nil {

--- a/pkg/parser/arguments_parser.go
+++ b/pkg/parser/arguments_parser.go
@@ -8,53 +8,32 @@ import (
 
 func (p *Parser) parseArguments(index *[]int) error {
 
-	key, err := p.l.Peek(true)
-	if err != nil {
-		return err
-	}
+	key := p.l.Peek(true)
 
 	if key != keyword.BRACKETOPEN {
 		return nil
 	}
 
-	_, err = p.l.Read()
-	if err != nil {
-		return err
-	}
-
+	p.l.Read()
 	var valueName document.ByteSliceReference
 
 	for {
-		key, err = p.l.Peek(true)
-		if err != nil {
-			return err
-		}
-
+		key = p.l.Peek(true)
 		if key == keyword.IDENT {
-			identToken, err := p.l.Read()
-			if err != nil {
-				return err
-			}
-
+			identToken := p.l.Read()
 			valueName = identToken.Literal
 
 		} else if key == keyword.BRACKETCLOSE {
-			_, err = p.l.Read()
-			return err
+			_ = p.l.Read()
+			return nil
 		} else {
 			return fmt.Errorf("parseArguments: ident/bracketclose expected, got %s", key)
 		}
 
-		key, err = p.l.Peek(true)
-		if err != nil {
-			return err
-		}
+		key = p.l.Peek(true)
 
 		if key == keyword.COLON {
-			_, err = p.l.Read()
-			if err != nil {
-				return err
-			}
+			_ = p.l.Read()
 		} else {
 			return fmt.Errorf("parseArguments: colon expected, got %s", key)
 		}

--- a/pkg/parser/bool_value_parser.go
+++ b/pkg/parser/bool_value_parser.go
@@ -4,18 +4,13 @@ import (
 	"github.com/jensneuse/graphql-go-tools/pkg/lexing/keyword"
 )
 
-func (p *Parser) parsePeekedBoolValue(index *int) error {
+func (p *Parser) parsePeekedBoolValue(index *int) {
 
-	tok, err := p.l.Read()
-	if err != nil {
-		return err
-	}
+	tok := p.l.Read()
 
 	if tok.Keyword == keyword.FALSE {
 		*index = 0
 	} else {
 		*index = 1
 	}
-
-	return nil
 }

--- a/pkg/parser/byteslice_parser.go
+++ b/pkg/parser/byteslice_parser.go
@@ -1,12 +1,6 @@
 package parser
 
-func (p *Parser) parsePeekedByteSlice(index *int) error {
-
-	variableToken, err := p.l.Read()
-	if err != nil {
-		return err
-	}
-
+func (p *Parser) parsePeekedByteSlice(index *int) {
+	variableToken := p.l.Read()
 	*index = p.putByteSliceReference(variableToken.Literal)
-	return nil
 }

--- a/pkg/parser/directivedefinition_parser.go
+++ b/pkg/parser/directivedefinition_parser.go
@@ -32,21 +32,12 @@ func (p *Parser) parseDirectiveDefinition(index *[]int) error {
 	}
 
 	for {
-		next, err := p.l.Peek(true)
-		if err != nil {
-			return err
-		}
+		next := p.l.Peek(true)
 
 		if next == keyword.PIPE {
-			_, err = p.l.Read()
-			if err != nil {
-				return err
-			}
+			p.l.Read()
 		} else if next == keyword.IDENT {
-			location, err := p.l.Read()
-			if err != nil {
-				return err
-			}
+			location := p.l.Read()
 
 			parsedLocation, err := document.ParseDirectiveLocation(p.ByteSlice(location.Literal))
 			if err != nil {

--- a/pkg/parser/directives_parser.go
+++ b/pkg/parser/directives_parser.go
@@ -8,17 +8,11 @@ import (
 func (p *Parser) parseDirectives(index *[]int) error {
 
 	for {
-		next, err := p.l.Peek(true)
-		if err != nil {
-			return err
-		}
+		next := p.l.Peek(true)
 
 		if next == keyword.AT {
 
-			_, err = p.l.Read()
-			if err != nil {
-				return err
-			}
+			p.l.Read()
 
 			ident, err := p.readExpect(keyword.IDENT, "parseDirectives")
 			if err != nil {
@@ -37,7 +31,7 @@ func (p *Parser) parseDirectives(index *[]int) error {
 			*index = append(*index, p.putDirective(directive))
 
 		} else {
-			return err
+			return nil
 		}
 	}
 }

--- a/pkg/parser/enumvaluesdefinition_parser.go
+++ b/pkg/parser/enumvaluesdefinition_parser.go
@@ -19,27 +19,16 @@ func (p *Parser) parseEnumValuesDefinition(index *[]int) error {
 	var description *document.ByteSliceReference
 
 	for {
-		next, err := p.l.Peek(true)
-		if err != nil {
-			return err
-		}
+		next := p.l.Peek(true)
 
 		if next == keyword.STRING {
 
-			stringToken, err := p.l.Read()
-			if err != nil {
-				return err
-			}
-
+			stringToken := p.l.Read()
 			description = &stringToken.Literal
 			continue
 
 		} else if next == keyword.IDENT {
-			ident, err := p.l.Read()
-			if err != nil {
-				return err
-			}
-
+			ident := p.l.Read()
 			definition := p.makeEnumValueDefinition()
 			definition.EnumValue = ident.Literal
 			if description != nil {
@@ -57,11 +46,11 @@ func (p *Parser) parseEnumValuesDefinition(index *[]int) error {
 			continue
 
 		} else if next == keyword.CURLYBRACKETCLOSE {
-			_, err = p.l.Read()
-			return err
+			p.l.Read()
+			return nil
 		}
 
-		invalid, _ := p.l.Read()
+		invalid := p.l.Read()
 		return newErrInvalidType(invalid.TextPosition, "parseEnumValuesDefinition", "string/ident/curlyBracketClose", invalid.Keyword.String())
 	}
 }

--- a/pkg/parser/executabledefinition_parser.go
+++ b/pkg/parser/executabledefinition_parser.go
@@ -43,18 +43,12 @@ func (p *Parser) parseComplexExecutableDefinition() (executableDefinition docume
 	executableDefinition = p.makeExecutableDefinition()
 
 	for {
-		next, err := p.l.Peek(true)
-		if err != nil {
-			return executableDefinition, err
-		}
+		next := p.l.Peek(true)
 
 		switch next {
 		case keyword.FRAGMENT:
 
-			_, err = p.l.Read()
-			if err != nil {
-				return executableDefinition, err
-			}
+			p.l.Read()
 
 			err := p.parseFragmentDefinition(&executableDefinition.FragmentDefinitions)
 			if err != nil {
@@ -71,7 +65,7 @@ func (p *Parser) parseComplexExecutableDefinition() (executableDefinition docume
 		default:
 
 			if len(executableDefinition.OperationDefinitions) == 0 {
-				invalid, _ := p.l.Read()
+				invalid := p.l.Read()
 				err = newErrInvalidType(invalid.TextPosition, "parseComplexExecutableDefinition", "fragment/query/mutation/subscription", next.String())
 			}
 

--- a/pkg/parser/field_parser.go
+++ b/pkg/parser/field_parser.go
@@ -10,11 +10,7 @@ func (p *Parser) parseField(index *[]int) (err error) {
 	var field document.Field
 	p.initField(&field)
 
-	firstIdent, err := p.l.Read()
-	if err != nil {
-		return err
-	}
-
+	firstIdent := p.l.Read()
 	field.Name = firstIdent.Literal
 
 	hasAlias, err := p.peekExpect(keyword.COLON, true)

--- a/pkg/parser/fieldsdefinition_parser.go
+++ b/pkg/parser/fieldsdefinition_parser.go
@@ -19,30 +19,19 @@ func (p *Parser) parseFieldsDefinition(index *[]int) (err error) {
 	var description *document.ByteSliceReference
 
 	for {
-		next, err := p.l.Peek(true)
-		if err != nil {
-			return err
-		}
+		next := p.l.Peek(true)
 
 		switch next {
 		case keyword.STRING:
-			stringToken, err := p.l.Read()
-			if err != nil {
-				return err
-			}
-
+			stringToken := p.l.Read()
 			description = &stringToken.Literal
 
 		case keyword.CURLYBRACKETCLOSE:
-			_, err = p.l.Read()
-			return err
+			p.l.Read()
+			return nil
 		case keyword.IDENT, keyword.TYPE:
 
-			fieldIdent, err := p.l.Read()
-			if err != nil {
-				return err
-			}
-
+			fieldIdent := p.l.Read()
 			definition := p.makeFieldDefinition()
 			if description != nil {
 				definition.Description = *description
@@ -73,7 +62,7 @@ func (p *Parser) parseFieldsDefinition(index *[]int) (err error) {
 
 			*index = append(*index, p.putFieldDefinition(definition))
 		default:
-			invalid, _ := p.l.Read()
+			invalid := p.l.Read()
 			return newErrInvalidType(invalid.TextPosition, "parseFieldsDefinition", "string/curly bracket close/ident", invalid.Keyword.String())
 		}
 	}

--- a/pkg/parser/float_value_parser.go
+++ b/pkg/parser/float_value_parser.go
@@ -6,10 +6,7 @@ import (
 
 func (p *Parser) parsePeekedFloatValue(index *int) error {
 
-	floatToken, err := p.l.Read()
-	if err != nil {
-		return err
-	}
+	floatToken := p.l.Read()
 
 	float, err := transform.StringToFloat32(p.ByteSlice(floatToken.Literal))
 	if err != nil {

--- a/pkg/parser/inputvaluedefinitions_parser.go
+++ b/pkg/parser/inputvaluedefinitions_parser.go
@@ -16,28 +16,18 @@ func (p *Parser) parseInputValueDefinitions(index *[]int, closeKeyword keyword.K
 	var description *document.ByteSliceReference
 
 	for {
-		next, err := p.l.Peek(true)
-		if err != nil {
-			return err
-		}
+		next := p.l.Peek(true)
 
 		if next == keyword.STRING {
 
-			quote, err := p.l.Read()
-			if err != nil {
-				return err
-			}
+			quote := p.l.Read()
 
 			//*description = transform.TrimWhitespace(p.ByteSlice(quote.Literal)) TODO: fix trimming
 			description = &quote.Literal
 
 		} else if next == keyword.IDENT {
 
-			ident, err := p.l.Read()
-			if err != nil {
-				return err
-			}
-
+			ident := p.l.Read()
 			definition := p.makeInputValueDefinition()
 			if description != nil {
 				definition.Description = *description
@@ -46,7 +36,7 @@ func (p *Parser) parseInputValueDefinitions(index *[]int, closeKeyword keyword.K
 
 			description = nil
 
-			_, err = p.readExpect(keyword.COLON, "parseInputValueDefinitions")
+			_, err := p.readExpect(keyword.COLON, "parseInputValueDefinitions")
 			if err != nil {
 				return err
 			}
@@ -69,7 +59,7 @@ func (p *Parser) parseInputValueDefinitions(index *[]int, closeKeyword keyword.K
 			*index = append(*index, p.putInputValueDefinition(definition))
 
 		} else if next != closeKeyword && closeKeyword != keyword.UNDEFINED {
-			invalid, _ := p.l.Read()
+			invalid := p.l.Read()
 			return newErrInvalidType(invalid.TextPosition, "parseInputValueDefinitions", "string/ident/"+closeKeyword.String(), invalid.String())
 		} else {
 			return nil

--- a/pkg/parser/int_value_parser.go
+++ b/pkg/parser/int_value_parser.go
@@ -6,10 +6,7 @@ import (
 
 func (p *Parser) parsePeekedIntValue(index *int) error {
 
-	integerToken, err := p.l.Read()
-	if err != nil {
-		return err
-	}
+	integerToken := p.l.Read()
 
 	integer, err := transform.StringToInt32(p.ByteSlice(integerToken.Literal))
 	if err != nil {

--- a/pkg/parser/list_value_parser.go
+++ b/pkg/parser/list_value_parser.go
@@ -6,31 +6,20 @@ import (
 
 func (p *Parser) parsePeekedListValue(index *int) error {
 
-	_, err := p.l.Read()
-	if err != nil {
-		return nil
-	}
+	p.l.Read()
 
 	listValue := p.makeListValue(index)
-	var peeked keyword.Keyword
 
 	for {
-		peeked, err = p.l.Peek(true)
-		if err != nil {
-			return err
-		}
 
-		switch peeked {
-		case keyword.SQUAREBRACKETCLOSE:
-			_, err = p.l.Read()
-			if err != nil {
-				return err
-			}
+		peeked := p.l.Peek(true)
 
+		if peeked == keyword.SQUAREBRACKETCLOSE {
+			p.l.Read()
 			p.putListValue(listValue, *index)
 			return nil
 
-		default:
+		} else {
 
 			var next int
 			err := p.parseValue(&next)

--- a/pkg/parser/object_value_parser.go
+++ b/pkg/parser/object_value_parser.go
@@ -8,44 +8,30 @@ import (
 
 func (p *Parser) parsePeekedObjectValue(index *int) error {
 
-	_, err := p.l.Read()
-	if err != nil {
-		return err
-	}
+	p.l.Read()
 
 	objectValue := p.makeObjectValue(index)
 
 	var peeked keyword.Keyword
 
 	for {
-		peeked, err = p.l.Peek(true)
-		if err != nil {
-			return err
-		}
+		peeked = p.l.Peek(true)
 
 		switch peeked {
 		case keyword.CURLYBRACKETCLOSE:
 
-			_, err = p.l.Read()
-			if err != nil {
-				return err
-			}
-
+			p.l.Read()
 			p.putObjectValue(objectValue, *index)
 			return nil
 
 		case keyword.IDENT:
 
-			identToken, err := p.l.Read()
-			if err != nil {
-				return err
-			}
-
+			identToken := p.l.Read()
 			field := document.ObjectField{
 				Name: identToken.Literal,
 			}
 
-			_, err = p.readExpect(keyword.COLON, "parsePeekedObjectValue")
+			_, err := p.readExpect(keyword.COLON, "parsePeekedObjectValue")
 			if err != nil {
 				return err
 			}

--- a/pkg/parser/operationdefinition_parser.go
+++ b/pkg/parser/operationdefinition_parser.go
@@ -11,21 +11,18 @@ func (p *Parser) parseOperationDefinition(index *[]int) (err error) {
 	var operationDefinition document.OperationDefinition
 	p.initOperationDefinition(&operationDefinition)
 
-	operationType, err := p.l.Peek(true)
-	if err != nil {
-		return err
-	}
+	operationType := p.l.Peek(true)
 
 	switch operationType {
 	case keyword.QUERY:
 		operationDefinition.OperationType = document.OperationTypeQuery
-		_, err = p.l.Read()
+		p.l.Read()
 	case keyword.MUTATION:
 		operationDefinition.OperationType = document.OperationTypeMutation
-		_, err = p.l.Read()
+		p.l.Read()
 	case keyword.SUBSCRIPTION:
 		operationDefinition.OperationType = document.OperationTypeSubscription
-		_, err = p.l.Read()
+		p.l.Read()
 	default:
 		operationDefinition.OperationType = document.OperationTypeQuery
 	}
@@ -40,10 +37,7 @@ func (p *Parser) parseOperationDefinition(index *[]int) (err error) {
 	}
 
 	if isNamedOperation {
-		name, err := p.l.Read()
-		if err != nil {
-			return err
-		}
+		name := p.l.Read()
 		operationDefinition.Name = name.Literal
 	}
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -86,8 +86,8 @@ type ParsedDefinitions struct {
 // Lexer is the interface used by the Parser to lex tokens
 type Lexer interface {
 	SetInput(input []byte) error
-	Read() (tok token.Token, err error)
-	Peek(ignoreWhitespace bool) (key keyword.Keyword, err error)
+	Read() (tok token.Token)
+	Peek(ignoreWhitespace bool) keyword.Keyword
 	ByteSlice(reference document.ByteSliceReference) document.ByteSlice
 }
 
@@ -165,11 +165,7 @@ func (p *Parser) ParseExecutableDefinition(input []byte) (definition document.Ex
 }
 
 func (p *Parser) readExpect(expected keyword.Keyword, enclosingFunctionName string) (t token.Token, err error) {
-	t, err = p.l.Read()
-	if err != nil {
-		return t, err
-	}
-
+	t = p.l.Read()
 	if t.Keyword != expected {
 		return t, newErrInvalidType(t.TextPosition, enclosingFunctionName, expected.String(), t.Keyword.String()+" lit: "+string(p.ByteSlice(t.Literal)))
 	}
@@ -178,7 +174,7 @@ func (p *Parser) readExpect(expected keyword.Keyword, enclosingFunctionName stri
 }
 
 func (p *Parser) peekExpect(expected keyword.Keyword, swallow bool) (matched bool, err error) {
-	next, err := p.l.Peek(true)
+	next := p.l.Peek(true)
 	if err != nil {
 		return false, err
 	}
@@ -186,7 +182,7 @@ func (p *Parser) peekExpect(expected keyword.Keyword, swallow bool) (matched boo
 	matched = next == expected
 
 	if matched && swallow {
-		_, err = p.l.Read()
+		p.l.Read()
 	}
 
 	return

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -689,10 +689,7 @@ func TestParser(t *testing.T) {
 
 	mustParseLiteral := func(wantKeyword keyword.Keyword, wantLiteral string) checkFunc {
 		return func(parser *Parser, i int) {
-			next, err := parser.l.Read()
-			if err != nil {
-				panic(err)
-			}
+			next := parser.l.Read()
 
 			gotKeyword := next.Keyword
 			gotLiteral := string(parser.ByteSlice(next.Literal))

--- a/pkg/parser/schemadefinition_parser.go
+++ b/pkg/parser/schemadefinition_parser.go
@@ -20,10 +20,7 @@ func (p *Parser) parseSchemaDefinition() (definition document.SchemaDefinition, 
 	}
 
 	for {
-		next, err := p.l.Read()
-		if err != nil {
-			return definition, err
-		}
+		next := p.l.Read()
 
 		switch next.Keyword {
 		case keyword.CURLYBRACKETCLOSE:

--- a/pkg/parser/selectionset_parser.go
+++ b/pkg/parser/selectionset_parser.go
@@ -18,14 +18,11 @@ func (p *Parser) parseSelectionSet(set *document.SelectionSet) (err error) {
 
 	for {
 
-		next, err := p.l.Peek(true)
-		if err != nil {
-			return err
-		}
+		next := p.l.Peek(true)
 
 		if next == keyword.CURLYBRACKETCLOSE {
-			_, err = p.l.Read()
-			return err
+			p.l.Read()
+			return nil
 		}
 
 		isFragmentSelection, err := p.peekExpect(keyword.SPREAD, true)

--- a/pkg/parser/typesystemdefinition_parser.go
+++ b/pkg/parser/typesystemdefinition_parser.go
@@ -12,10 +12,7 @@ func (p *Parser) parseTypeSystemDefinition() (definition document.TypeSystemDefi
 	var description *document.ByteSliceReference
 
 	for {
-		next, err := p.l.Read()
-		if err != nil {
-			return definition, err
-		}
+		next := p.l.Read()
 
 		switch next.Keyword {
 		case keyword.EOF:
@@ -116,7 +113,7 @@ func (p *Parser) parseTypeSystemDefinition() (definition document.TypeSystemDefi
 			}
 
 		default:
-			invalid, _ := p.l.Read()
+			invalid := p.l.Read()
 			return definition, newErrInvalidType(invalid.TextPosition, "parseTypeSystemDefinition", "eof/string/schema/scalar/type/interface/union/directive/input/enum", invalid.Keyword.String())
 		}
 

--- a/pkg/parser/value_parser.go
+++ b/pkg/parser/value_parser.go
@@ -10,22 +10,18 @@ var (
 	parseValuePossibleKeywords = []keyword.Keyword{keyword.FALSE, keyword.TRUE, keyword.VARIABLE, keyword.INTEGER, keyword.FLOAT, keyword.STRING, keyword.NULL, keyword.IDENT, keyword.SQUAREBRACKETOPEN, keyword.SQUAREBRACKETCLOSE}
 )
 
-func (p *Parser) parseValue(index *int) error {
+func (p *Parser) parseValue(index *int) (err error) {
 
-	key, err := p.l.Peek(true)
-	if err != nil {
-		return err
-	}
-
+	key := p.l.Peek(true)
 	value := p.makeValue(index)
 
 	switch key {
 	case keyword.FALSE, keyword.TRUE:
 		value.ValueType = document.ValueTypeBoolean
-		err = p.parsePeekedBoolValue(&value.Reference)
+		p.parsePeekedBoolValue(&value.Reference)
 	case keyword.VARIABLE:
 		value.ValueType = document.ValueTypeVariable
-		err = p.parsePeekedByteSlice(&value.Reference)
+		p.parsePeekedByteSlice(&value.Reference)
 	case keyword.INTEGER:
 		value.ValueType = document.ValueTypeInt
 		err = p.parsePeekedIntValue(&value.Reference)
@@ -34,13 +30,13 @@ func (p *Parser) parseValue(index *int) error {
 		err = p.parsePeekedFloatValue(&value.Reference)
 	case keyword.STRING:
 		value.ValueType = document.ValueTypeString
-		err = p.parsePeekedByteSlice(&value.Reference)
+		p.parsePeekedByteSlice(&value.Reference)
 	case keyword.NULL:
 		value.ValueType = document.ValueTypeNull
-		_, err = p.l.Read()
+		p.l.Read()
 	case keyword.IDENT:
 		value.ValueType = document.ValueTypeEnum
-		err = p.parsePeekedByteSlice(&value.Reference)
+		p.parsePeekedByteSlice(&value.Reference)
 	case keyword.SQUAREBRACKETOPEN:
 		value.ValueType = document.ValueTypeList
 		err = p.parsePeekedListValue(&value.Reference)
@@ -48,7 +44,7 @@ func (p *Parser) parseValue(index *int) error {
 		value.ValueType = document.ValueTypeObject
 		err = p.parsePeekedObjectValue(&value.Reference)
 	default:
-		invalidToken, _ := p.l.Read()
+		invalidToken := p.l.Read()
 		return newErrInvalidType(invalidToken.TextPosition, "parseValue", fmt.Sprintf("%v", parseValuePossibleKeywords), string(invalidToken.Keyword))
 	}
 

--- a/pkg/parser/variabledefinitions_parser.go
+++ b/pkg/parser/variabledefinitions_parser.go
@@ -17,18 +17,12 @@ func (p *Parser) parseVariableDefinitions(index *[]int) (err error) {
 	}
 
 	for {
-		next, err := p.l.Peek(true)
-		if err != nil {
-			return err
-		}
+		next := p.l.Peek(true)
 
 		switch next {
 		case keyword.VARIABLE:
 
-			variable, err := p.l.Read()
-			if err != nil {
-				return err
-			}
+			variable := p.l.Read()
 
 			variableDefinition := document.VariableDefinition{
 				Variable: variable.Literal,
@@ -52,10 +46,10 @@ func (p *Parser) parseVariableDefinitions(index *[]int) (err error) {
 			*index = append(*index, p.putVariableDefinition(variableDefinition))
 
 		case keyword.BRACKETCLOSE:
-			_, err = p.l.Read()
+			p.l.Read()
 			return err
 		default:
-			invalid, _ := p.l.Read()
+			invalid := p.l.Read()
 			return newErrInvalidType(invalid.TextPosition, "parseVariableDefinitions", "variable/bracket close", invalid.Keyword.String())
 		}
 	}


### PR DESCRIPTION
This PR simplifies the code of the Lexer by changing it's signature of both Peek and Read to not emit errors but only keywords/tokens. Tests are updated accordingly.