### PR TITLE
Selectionset parsing allocs

### DIFF
--- a/pkg/parser/field_parser.go
+++ b/pkg/parser/field_parser.go
@@ -5,7 +5,7 @@ import (
 	"github.com/jensneuse/graphql-go-tools/pkg/lexing/keyword"
 )
 
-func (p *Parser) parseField(index *[]int) (err error) {
+func (p *Parser) parseField() (ref int, err error) {
 
 	var field document.Field
 	p.initField(&field)
@@ -20,7 +20,7 @@ func (p *Parser) parseField(index *[]int) (err error) {
 		field.Alias = field.Name
 		fieldName, err := p.readExpect(keyword.IDENT, "parseField")
 		if err != nil {
-			return err
+			return ref, err
 		}
 
 		field.Name = p.putByteSliceReference(fieldName.Literal)
@@ -28,12 +28,12 @@ func (p *Parser) parseField(index *[]int) (err error) {
 
 	err = p.parseArgumentSet(&field.ArgumentSet)
 	if err != nil {
-		return
+		return ref, err
 	}
 
 	err = p.parseDirectives(&field.DirectiveSet)
 	if err != nil {
-		return
+		return ref, err
 	}
 
 	err = p.parseSelectionSet(&field.SelectionSet)
@@ -56,7 +56,5 @@ func (p *Parser) parseField(index *[]int) (err error) {
 		field.Position.MergeStartIntoEnd(p.TextPosition())
 	}
 
-	*index = append(*index, p.putField(field))
-
-	return
+	return p.putField(field), err
 }

--- a/pkg/parser/fragmentspread_parser.go
+++ b/pkg/parser/fragmentspread_parser.go
@@ -5,25 +5,23 @@ import (
 	"github.com/jensneuse/graphql-go-tools/pkg/lexing/position"
 )
 
-func (p *Parser) parseFragmentSpread(startPosition position.Position, index *[]int) error {
+func (p *Parser) parseFragmentSpread(startPosition position.Position) (ref int, err error) {
 
 	fragmentSpread := p.makeFragmentSpread()
 	fragmentSpread.Position.MergeStartIntoStart(startPosition)
 
 	fragmentIdent, err := p.readExpect(keyword.IDENT, "parseFragmentSpread")
 	if err != nil {
-		return err
+		return ref, err
 	}
 
 	fragmentSpread.FragmentName = p.putByteSliceReference(fragmentIdent.Literal)
 	err = p.parseDirectives(&fragmentSpread.DirectiveSet)
 	if err != nil {
-		return err
+		return ref, err
 	}
 
 	fragmentSpread.Position.MergeStartIntoEnd(p.TextPosition())
 
-	*index = append(*index, p.putFragmentSpread(fragmentSpread))
-
-	return nil
+	return p.putFragmentSpread(fragmentSpread), err
 }

--- a/pkg/parser/inlinefragment_parser.go
+++ b/pkg/parser/inlinefragment_parser.go
@@ -6,7 +6,7 @@ import (
 	"github.com/jensneuse/graphql-go-tools/pkg/lexing/position"
 )
 
-func (p *Parser) parseInlineFragment(startPosition position.Position, index *[]int) error {
+func (p *Parser) parseInlineFragment(startPosition position.Position) (ref int, err error) {
 
 	var fragment document.InlineFragment
 	p.initInlineFragment(&fragment)
@@ -16,7 +16,7 @@ func (p *Parser) parseInlineFragment(startPosition position.Position, index *[]i
 	if hasTypeCondition {
 		fragmentIdent, err := p.readExpect(keyword.IDENT, "parseInlineFragment")
 		if err != nil {
-			return err
+			return ref, err
 		}
 		fragmentType := p.makeType(&fragment.TypeCondition)
 		fragmentType.Name = p.putByteSliceReference(fragmentIdent.Literal)
@@ -24,17 +24,16 @@ func (p *Parser) parseInlineFragment(startPosition position.Position, index *[]i
 		p.putType(fragmentType, fragment.TypeCondition)
 	}
 
-	err := p.parseDirectives(&fragment.DirectiveSet)
+	err = p.parseDirectives(&fragment.DirectiveSet)
 	if err != nil {
-		return err
+		return ref, err
 	}
 
 	err = p.parseSelectionSet(&fragment.SelectionSet)
 	if err != nil {
-		return err
+		return ref, err
 	}
 
 	fragment.Position.MergeStartIntoEnd(p.TextPosition())
-	*index = append(*index, p.putInlineFragment(fragment))
-	return nil
+	return p.putInlineFragment(fragment), err
 }

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -688,18 +688,15 @@ func TestParser(t *testing.T) {
 		}
 	}
 
-	mustParseFields := func(rules ...ruleSet) checkFunc {
+	mustParseFields := func(rule ruleSet) checkFunc {
 		return func(parser *Parser, i int) {
-			var index []int
-			if err := parser.parseField(&index); err != nil {
+			fieldRef, err := parser.parseField()
+			if err != nil {
 				panic(err)
 			}
 
-			for j, rule := range rules {
-				reverseIndex := len(parser.ParsedDefinitions.Fields) - 1 - j
-				field := parser.ParsedDefinitions.Fields[reverseIndex]
-				evalRules(field, parser, rule, i)
-			}
+			field := parser.ParsedDefinitions.Fields[fieldRef]
+			evalRules(field, parser, rule, i)
 		}
 	}
 
@@ -732,17 +729,15 @@ func TestParser(t *testing.T) {
 		}
 	}
 
-	mustParseFragmentSpread := func(rules ...ruleSet) checkFunc {
+	mustParseFragmentSpread := func(rule ruleSet) checkFunc {
 		return func(parser *Parser, i int) {
-			var index []int
-			if err := parser.parseFragmentSpread(position.Position{}, &index); err != nil {
+			fragmentSpreadRef, err := parser.parseFragmentSpread(position.Position{})
+			if err != nil {
 				panic(err)
 			}
 
-			for j, rule := range rules {
-				spread := parser.ParsedDefinitions.FragmentSpreads[j]
-				evalRules(spread, parser, rule, i)
-			}
+			spread := parser.ParsedDefinitions.FragmentSpreads[fragmentSpreadRef]
+			evalRules(spread, parser, rule, i)
 		}
 	}
 
@@ -780,18 +775,15 @@ func TestParser(t *testing.T) {
 		}
 	}
 
-	mustParseInlineFragments := func(rules ...ruleSet) checkFunc {
+	mustParseInlineFragments := func(rule ruleSet) checkFunc {
 		return func(parser *Parser, i int) {
-			var index []int
-			if err := parser.parseInlineFragment(position.Position{}, &index); err != nil {
+			inlineFragmentRef, err := parser.parseInlineFragment(position.Position{})
+			if err != nil {
 				panic(err)
 			}
 
-			for j, rule := range rules {
-				reverseIndex := len(parser.ParsedDefinitions.InlineFragments) - 1 - j
-				inlineFragment := parser.ParsedDefinitions.InlineFragments[reverseIndex]
-				evalRules(inlineFragment, parser, rule, i)
-			}
+			inlineFragment := parser.ParsedDefinitions.InlineFragments[inlineFragmentRef]
+			evalRules(inlineFragment, parser, rule, i)
 		}
 	}
 
@@ -2278,10 +2270,10 @@ func TestParser(t *testing.T) {
 		)
 	})
 	t.Run("invalid", func(t *testing.T) {
-		run("on", mustPanic(mustParseFragmentSpread()))
+		run("on", mustPanic(mustParseFragmentSpread(node())))
 	})
 	t.Run("invalid 2", func(t *testing.T) {
-		run("afragment @foo(bar: .)", mustPanic(mustParseFragmentSpread()))
+		run("afragment @foo(bar: .)", mustPanic(mustParseFragmentSpread(node())))
 	})
 
 	// parseImplementsInterfaces
@@ -2455,7 +2447,7 @@ func TestParser(t *testing.T) {
 						... on [Water] {
 							waterField
 						}
-					}`, mustPanic(mustParseInlineFragments()))
+					}`, mustPanic(mustParseInlineFragments(node())))
 	})
 
 	// parseInputFieldsDefinition

--- a/pkg/parser/selectionset_parser.go
+++ b/pkg/parser/selectionset_parser.go
@@ -32,25 +32,36 @@ func (p *Parser) parseSelectionSet(ref *int) (err error) {
 
 		isFragmentSelection := p.peekExpect(keyword.SPREAD, false)
 		if !isFragmentSelection {
-			err := p.parseField(&set.Fields)
+
+			field, err := p.parseField()
 			if err != nil {
 				return err
 			}
+
+			set.Fields = append(set.Fields, field)
+
 		} else {
 
 			start := p.l.Read()
 
 			isFragmentSpread := p.peekExpect(keyword.IDENT, false)
 			if isFragmentSpread {
-				err := p.parseFragmentSpread(start.TextPosition, &set.FragmentSpreads)
+
+				fragmentSpread, err := p.parseFragmentSpread(start.TextPosition)
 				if err != nil {
 					return err
 				}
+
+				set.FragmentSpreads = append(set.FragmentSpreads, fragmentSpread)
+
 			} else {
-				err := p.parseInlineFragment(start.TextPosition, &set.InlineFragments)
+
+				inlineFragment, err := p.parseInlineFragment(start.TextPosition)
 				if err != nil {
 					return err
 				}
+
+				set.InlineFragments = append(set.InlineFragments, inlineFragment)
 			}
 		}
 	}


### PR DESCRIPTION
This PR will fix some regressions found in the recent push that led to an increase in allocations and a decrease in performance (up to 20%).
There were only a few little changes necessary to make the escape analyzer happy.
The outcome is also easier to read/maintain code for parsing selection sets.
Testing also became simpler.