### PR TITLE
55 context middleware quote input

### DIFF
--- a/pkg/middleware/context_middleware.go
+++ b/pkg/middleware/context_middleware.go
@@ -1,11 +1,14 @@
 package middleware
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"github.com/jensneuse/graphql-go-tools/pkg/document"
+	"github.com/jensneuse/graphql-go-tools/pkg/lexing/literal"
 	"github.com/jensneuse/graphql-go-tools/pkg/lookup"
 	"github.com/jensneuse/graphql-go-tools/pkg/parser"
+	"strings"
 )
 
 /*
@@ -135,11 +138,17 @@ func (a *ContextMiddleware) OnRequest(ctx context.Context, l *lookup.Lookup, w *
 
 					switch argumentValue := argumentValue.(type) {
 					case string:
+						if !strings.HasPrefix(argumentValue, "\"") {
+							argumentValue = "\"" + argumentValue + "\""
+						}
 						argByteSliceRef, argNameRef, err = mod.PutLiteralString(argumentValue)
 						if err != nil {
 							return err
 						}
 					case []byte:
+						if !bytes.HasPrefix(argumentValue, literal.QUOTE) {
+							argumentValue = append(literal.QUOTE, append(argumentValue, literal.QUOTE...)...)
+						}
 						argByteSliceRef, argNameRef, err = mod.PutLiteralBytes(argumentValue)
 						if err != nil {
 							return err

--- a/pkg/middleware/context_middleware.go
+++ b/pkg/middleware/context_middleware.go
@@ -139,7 +139,10 @@ func (a *ContextMiddleware) OnRequest(ctx context.Context, l *lookup.Lookup, w *
 					switch argumentValue := argumentValue.(type) {
 					case string:
 						if !strings.HasPrefix(argumentValue, "\"") {
-							argumentValue = "\"" + argumentValue + "\""
+							argumentValue = "\"" + argumentValue
+						}
+						if !strings.HasSuffix(argumentValue, "\"") {
+							argumentValue = argumentValue + "\""
 						}
 						argByteSliceRef, argNameRef, err = mod.PutLiteralString(argumentValue)
 						if err != nil {
@@ -147,7 +150,10 @@ func (a *ContextMiddleware) OnRequest(ctx context.Context, l *lookup.Lookup, w *
 						}
 					case []byte:
 						if !bytes.HasPrefix(argumentValue, literal.QUOTE) {
-							argumentValue = append(literal.QUOTE, append(argumentValue, literal.QUOTE...)...)
+							argumentValue = append(literal.QUOTE, argumentValue...)
+						}
+						if !bytes.HasSuffix(argumentValue, literal.QUOTE) {
+							argumentValue = append(argumentValue, literal.QUOTE...)
 						}
 						argByteSliceRef, argNameRef, err = mod.PutLiteralBytes(argumentValue)
 						if err != nil {

--- a/pkg/middleware/context_middleware_test.go
+++ b/pkg/middleware/context_middleware_test.go
@@ -24,22 +24,6 @@ func TestContextMiddleware(t *testing.T) {
 			panic(fmt.Errorf("\nwant:\n%s\ngot:\n%s", want, got))
 		}
 	})
-	t.Run("simple string", func(t *testing.T) {
-
-		// it's important to quote the value so the lexer will recognize it's a string value
-		// we might push this including checks into the implementation
-		ctx := context.WithValue(context.Background(), "user", "jsmith@example.org")
-
-		got, err := InvokeMiddleware(&ContextMiddleware{}, ctx, publicSchema, publicQuery)
-		if err != nil {
-			t.Fatal(err)
-		}
-		want := testhelper.UglifyRequestString(privateQuery)
-
-		if want != got {
-			panic(fmt.Errorf("\nwant:\n%s\ngot:\n%s", want, got))
-		}
-	})
 	t.Run("unquoted byte slice string should be quoted automatically", func(t *testing.T) {
 
 		// it's important to quote the value so the lexer will recognize it's a string value
@@ -67,6 +51,70 @@ func TestContextMiddleware(t *testing.T) {
 			t.Fatal(err)
 		}
 		want := testhelper.UglifyRequestString(privateQuery)
+
+		if want != got {
+			panic(fmt.Errorf("\nwant:\n%s\ngot:\n%s", want, got))
+		}
+	})
+	t.Run("unquoted string should be quoted automatically", func(t *testing.T) {
+
+		// it's important to quote the value so the lexer will recognize it's a string value
+		// we might push this including checks into the implementation
+		ctx := context.WithValue(context.Background(), "user", "jsmith@example.org")
+
+		got, err := InvokeMiddleware(&ContextMiddleware{}, ctx, publicSchema, publicQuery)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := testhelper.UglifyRequestString(privateQuery)
+
+		if want != got {
+			panic(fmt.Errorf("\nwant:\n%s\ngot:\n%s", want, got))
+		}
+	})
+	t.Run("left side quoted string should be quoted automatically", func(t *testing.T) {
+
+		// it's important to quote the value so the lexer will recognize it's a string value
+		// we might push this including checks into the implementation
+		ctx := context.WithValue(context.Background(), "user", "\"jsmith@example.org")
+
+		got, err := InvokeMiddleware(&ContextMiddleware{}, ctx, publicSchema, publicQuery)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := testhelper.UglifyRequestString(privateQuery)
+
+		if want != got {
+			panic(fmt.Errorf("\nwant:\n%s\ngot:\n%s", want, got))
+		}
+	})
+	t.Run("right side quoted string should be quoted automatically", func(t *testing.T) {
+
+		// it's important to quote the value so the lexer will recognize it's a string value
+		// we might push this including checks into the implementation
+		ctx := context.WithValue(context.Background(), "user", "jsmith@example.org\"")
+
+		got, err := InvokeMiddleware(&ContextMiddleware{}, ctx, publicSchema, publicQuery)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := testhelper.UglifyRequestString(privateQuery)
+
+		if want != got {
+			panic(fmt.Errorf("\nwant:\n%s\ngot:\n%s", want, got))
+		}
+	})
+	t.Run("escaped quote inside", func(t *testing.T) {
+
+		// it's important to quote the value so the lexer will recognize it's a string value
+		// we might push this including checks into the implementation
+		ctx := context.WithValue(context.Background(), "user", "jsmith\\\"@example.org")
+
+		got, err := InvokeMiddleware(&ContextMiddleware{}, ctx, publicSchema, publicQuery)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := testhelper.UglifyRequestString(privateQueryWithEscapedQuote)
 
 		if want != got {
 			panic(fmt.Errorf("\nwant:\n%s\ngot:\n%s", want, got))
@@ -125,6 +173,14 @@ query myDocuments {
 const privateQuery = `
 query myDocuments {
 	documents(user: "jsmith@example.org") {
+		sensitiveInformation
+	}
+}
+`
+
+const privateQueryWithEscapedQuote = `
+query myDocuments {
+	documents(user: "jsmith\"@example.org") {
 		sensitiveInformation
 	}
 }

--- a/pkg/middleware/context_middleware_test.go
+++ b/pkg/middleware/context_middleware_test.go
@@ -24,6 +24,54 @@ func TestContextMiddleware(t *testing.T) {
 			panic(fmt.Errorf("\nwant:\n%s\ngot:\n%s", want, got))
 		}
 	})
+	t.Run("simple string", func(t *testing.T) {
+
+		// it's important to quote the value so the lexer will recognize it's a string value
+		// we might push this including checks into the implementation
+		ctx := context.WithValue(context.Background(), "user", "jsmith@example.org")
+
+		got, err := InvokeMiddleware(&ContextMiddleware{}, ctx, publicSchema, publicQuery)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := testhelper.UglifyRequestString(privateQuery)
+
+		if want != got {
+			panic(fmt.Errorf("\nwant:\n%s\ngot:\n%s", want, got))
+		}
+	})
+	t.Run("unquoted byte slice string should be quoted automatically", func(t *testing.T) {
+
+		// it's important to quote the value so the lexer will recognize it's a string value
+		// we might push this including checks into the implementation
+		ctx := context.WithValue(context.Background(), "user", []byte(`jsmith@example.org`))
+
+		got, err := InvokeMiddleware(&ContextMiddleware{}, ctx, publicSchema, publicQuery)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := testhelper.UglifyRequestString(privateQuery)
+
+		if want != got {
+			panic(fmt.Errorf("\nwant:\n%s\ngot:\n%s", want, got))
+		}
+	})
+	t.Run("unquoted string should be quoted automatically", func(t *testing.T) {
+
+		// it's important to quote the value so the lexer will recognize it's a string value
+		// we might push this including checks into the implementation
+		ctx := context.WithValue(context.Background(), "user", "jsmith@example.org")
+
+		got, err := InvokeMiddleware(&ContextMiddleware{}, ctx, publicSchema, publicQuery)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := testhelper.UglifyRequestString(privateQuery)
+
+		if want != got {
+			panic(fmt.Errorf("\nwant:\n%s\ngot:\n%s", want, got))
+		}
+	})
 }
 
 const publicSchema = `

--- a/pkg/middleware/context_middleware_test.go
+++ b/pkg/middleware/context_middleware_test.go
@@ -56,22 +56,6 @@ func TestContextMiddleware(t *testing.T) {
 			panic(fmt.Errorf("\nwant:\n%s\ngot:\n%s", want, got))
 		}
 	})
-	t.Run("unquoted string should be quoted automatically", func(t *testing.T) {
-
-		// it's important to quote the value so the lexer will recognize it's a string value
-		// we might push this including checks into the implementation
-		ctx := context.WithValue(context.Background(), "user", "jsmith@example.org")
-
-		got, err := InvokeMiddleware(&ContextMiddleware{}, ctx, publicSchema, publicQuery)
-		if err != nil {
-			t.Fatal(err)
-		}
-		want := testhelper.UglifyRequestString(privateQuery)
-
-		if want != got {
-			panic(fmt.Errorf("\nwant:\n%s\ngot:\n%s", want, got))
-		}
-	})
 	t.Run("left side quoted string should be quoted automatically", func(t *testing.T) {
 
 		// it's important to quote the value so the lexer will recognize it's a string value


### PR DESCRIPTION
This PR will implement the solution to #55
All inputs (strings/byte slices) will be quoted if they weren't already quoted.
This ensures both ease of use and correct handling by the lexer.
The literal provided to the lexer must be quoted so the lexer recognises a string.