### PR TITLE
Drop empty operation name

### DIFF
--- a/pkg/proxy/http/proxy.go
+++ b/pkg/proxy/http/proxy.go
@@ -24,7 +24,7 @@ type ProxyRequest struct {
 }
 
 type GraphqlJsonRequest struct {
-	OperationName string `json:"operationName"`
+	OperationName string `json:"operationName,omitempty"`
 	Query         string `json:"query"`
 }
 

--- a/pkg/proxy/http/proxy_integration_test.go
+++ b/pkg/proxy/http/proxy_integration_test.go
@@ -142,6 +142,6 @@ type Document implements Node {
 const publicQuery = `{"query":"query myDocuments {documents {sensitiveInformation}}"}
 `
 
-const privateQuery = `{"operationName":"","query":"query myDocuments {documents(user:\"jsmith@example.org\") {sensitiveInformation}}"}
+const privateQuery = `{"query":"query myDocuments {documents(user:\"jsmith@example.org\") {sensitiveInformation}}"}
 `
 const privateAuthHeader = "testAuth"

--- a/pkg/proxy/http/proxy_test.go
+++ b/pkg/proxy/http/proxy_test.go
@@ -132,5 +132,5 @@ type Asset implements Node {
 
 const assetInput = `{"query":"query testQueryWithoutHandle {assets(first: 1) { id fileName url(transformation: {image: {resize: {width: 100, height: 100}}})}}"}`
 
-const assetOutput = `{"operationName":"","query":"query testQueryWithoutHandle {assets(first:1) {id fileName handle}}"}
+const assetOutput = `{"query":"query testQueryWithoutHandle {assets(first:1) {id fileName handle}}"}
 `


### PR DESCRIPTION
This commit fixes a potential included empty operation name, which can cause problems with older graphql implementations