### PR TITLE
fix parsing on windows

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -135,7 +135,7 @@ func (l *Lexer) readComment(tok *token.Token) {
 		switch next {
 		case runes.EOF:
 			return
-		case runes.LINETERMINATOR:
+		case runes.CARRIAGERETURN, runes.LINETERMINATOR:
 			if l.peekRune(true) != runes.HASHTAG {
 				return
 			}
@@ -297,7 +297,7 @@ func runeIsDigit(r byte) bool {
 
 func (l *Lexer) byteIsWhitespace(r byte) bool {
 	switch r {
-	case runes.SPACE, runes.TAB, runes.LINETERMINATOR, runes.COMMA:
+	case runes.SPACE, runes.TAB, runes.CARRIAGERETURN, runes.LINETERMINATOR, runes.COMMA:
 		return true
 	default:
 		return false
@@ -308,6 +308,7 @@ func (l *Lexer) byteTerminatesSequence(r byte) bool {
 	switch r {
 	case runes.SPACE,
 		runes.TAB,
+		runes.CARRIAGERETURN,
 		runes.LINETERMINATOR,
 		runes.COMMA,
 		runes.LPAREN,
@@ -348,7 +349,7 @@ func (l *Lexer) readBlockString(tok *token.Token) {
 	for {
 		next := l.readRune()
 		switch next {
-		case runes.SPACE, runes.TAB, runes.LINETERMINATOR:
+		case runes.SPACE, runes.TAB, runes.CARRIAGERETURN, runes.LINETERMINATOR:
 			quoteCount = 0
 			whitespaceCount++
 		case runes.EOF:
@@ -406,7 +407,7 @@ func (l *Lexer) readSingleLineString(tok *token.Token) {
 			tok.Literal.Start += uint32(leadingWhitespaceToken)
 			tok.Literal.End -= uint32(whitespaceCount)
 			return
-		case runes.QUOTE, runes.LINETERMINATOR:
+		case runes.QUOTE, runes.CARRIAGERETURN, runes.LINETERMINATOR:
 			if escaped {
 				escaped = !escaped
 				continue

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -84,6 +84,9 @@ func TestLexer_Peek_Read(t *testing.T) {
 	t.Run("peek whitespace length with linebreak", func(t *testing.T) {
 		run("   \nfoo", mustPeekWhitespaceLength(4))
 	})
+	t.Run("peek whitespace length with carriage return", func(t *testing.T) {
+		run("   \rfoo", mustPeekWhitespaceLength(4))
+	})
 	t.Run("peek whitespace length with comma", func(t *testing.T) {
 		run("   ,foo", mustPeekWhitespaceLength(4))
 	})
@@ -127,8 +130,11 @@ func TestLexer_Peek_Read(t *testing.T) {
 	t.Run("read float with tab", func(t *testing.T) {
 		run("13.37	", mustRead(keyword.FLOAT, "13.37"))
 	})
-	t.Run("read with with lineTerminator", func(t *testing.T) {
+	t.Run("read with lineTerminator", func(t *testing.T) {
 		run("13.37\n", mustRead(keyword.FLOAT, "13.37"))
+	})
+	t.Run("read with carriage return and line feed", func(t *testing.T) {
+		run("13.37\r\n", mustRead(keyword.FLOAT, "13.37"))
 	})
 	t.Run("read float with comma", func(t *testing.T) {
 		run("13.37,", mustRead(keyword.FLOAT, "13.37"))
@@ -171,6 +177,9 @@ func TestLexer_Peek_Read(t *testing.T) {
 	t.Run("read multi line string", func(t *testing.T) {
 		run("\"\"\"\nfoo\nbar\"\"\"", mustRead(keyword.BLOCKSTRING, "foo\nbar"))
 	})
+	t.Run("read multi line string with carriage return", func(t *testing.T) {
+		run("\"\"\"\r\nfoo\r\nbar\"\"\"", mustRead(keyword.BLOCKSTRING, "foo\r\nbar"))
+	})
 	t.Run("read multi line string with escaped backslash", func(t *testing.T) {
 		run("\"\"\"foo \\\\ bar\"\"\"", mustRead(keyword.BLOCKSTRING, "foo \\\\ bar"))
 	})
@@ -187,6 +196,9 @@ func TestLexer_Peek_Read(t *testing.T) {
 	})
 	t.Run("complex multi line string", func(t *testing.T) {
 		run("\"\"\"block string uses \\\"\"\"\n\"\"\"", mustRead(keyword.BLOCKSTRING, "block string uses \\\"\"\""))
+	})
+	t.Run("complex multi line string with carriage return", func(t *testing.T) {
+		run("\"\"\"block string uses \\\"\"\"\r\n\"\"\"", mustRead(keyword.BLOCKSTRING, "block string uses \\\"\"\""))
 	})
 	t.Run("read multi line string with trailing leading/trailing whitespace combination", func(t *testing.T) {
 		run(`	"""	 	 
@@ -225,6 +237,10 @@ func TestLexer_Peek_Read(t *testing.T) {
 	})
 	t.Run("read variable 4", func(t *testing.T) {
 		run("$foo\n", mustRead(keyword.DOLLAR, "$"),
+			mustRead(keyword.IDENT, "foo"))
+	})
+	t.Run("read variable 4 with carriage return", func(t *testing.T) {
+		run("$foo\r\n", mustRead(keyword.DOLLAR, "$"),
 			mustRead(keyword.IDENT, "foo"))
 	})
 	t.Run("read err invalid variable", func(t *testing.T) {
@@ -302,6 +318,9 @@ func TestLexer_Peek_Read(t *testing.T) {
 	t.Run("read fragment", func(t *testing.T) {
 		run("\n\n fragment", mustRead(keyword.IDENT, "fragment"))
 	})
+	t.Run("read fragment with carriage return", func(t *testing.T) {
+		run("\r\n\r\n fragment", mustRead(keyword.IDENT, "fragment"))
+	})
 	t.Run("read implements", func(t *testing.T) {
 		run("implements", mustRead(keyword.IDENT, "implements"))
 	})
@@ -353,6 +372,9 @@ func TestLexer_Peek_Read(t *testing.T) {
 	t.Run("read ignore lineTerminator", func(t *testing.T) {
 		run("\n", mustRead(keyword.EOF, ""))
 	})
+	t.Run("read ignore lineTerminator with carriage return", func(t *testing.T) {
+		run("\r\n", mustRead(keyword.EOF, ""))
+	})
 	t.Run("read null", func(t *testing.T) {
 		run("null", mustRead(keyword.IDENT, "null"))
 	})
@@ -366,6 +388,12 @@ func TestLexer_Peek_Read(t *testing.T) {
 	})
 	t.Run("read single line comment", func(t *testing.T) {
 		run("# A connection to a list of items.\nident",
+			mustRead(keyword.COMMENT, "# A connection to a list of items."),
+			mustRead(keyword.IDENT, "ident"),
+		)
+	})
+	t.Run("read single line comment with carriage return", func(t *testing.T) {
+		run("# A connection to a list of items.\r\nident",
 			mustRead(keyword.COMMENT, "# A connection to a list of items."),
 			mustRead(keyword.IDENT, "ident"),
 		)

--- a/pkg/lexer/runes/runes.go
+++ b/pkg/lexer/runes/runes.go
@@ -4,6 +4,7 @@ const (
 	EOF            = 0
 	COLON          = ':'
 	BANG           = '!'
+	CARRIAGERETURN = '\r'
 	LINETERMINATOR = '\n'
 	TAB            = '\t'
 	SPACE          = ' '


### PR DESCRIPTION
Schema parsing on Windows is broken, because the carriage return (CR, "`\r`") is tokenized as `IDENT` instead of a whitespace.

So when parsing the default schema the parser throws following error:
````
starting testServer...
2019/10/26 16:12:48 external: unexpected token - got: IDENT want one of: [COLON], locations: [{Line:2 Column:5}], path: []
````

This PR should fix this issue and the parser should work now on Windows.
Tests has been added too.