### PR TITLE
ObjectType extension and extension removal

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -461,6 +461,11 @@ func (d *Document) ExtendObjectTypeByField(objectTypeRef, fieldRef int) {
 	return
 }
 
+func (d *Document) ExtendObjectTypeByDirective(objectTypeRef, directiveRef int) {
+	// TODO: implement
+	return
+}
+
 func (d *Document) NodeFieldDefinitions(node Node) []int {
 	switch node.Kind {
 	case NodeKindObjectTypeDefinition:

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -456,7 +456,7 @@ func (d *Document) FieldDefinitionTypeNode(ref int) Node {
 	return d.Index.Nodes[xxhash.Sum64(typeName)]
 }
 
-func (d *Document) ExtendTypeByField(ref int) {
+func (d *Document) ExtendObjectTypeByField(objectTypeRef, fieldRef int) {
 	// TODO: implement
 	return
 }

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -456,12 +456,12 @@ func (d *Document) FieldDefinitionTypeNode(ref int) Node {
 	return d.Index.Nodes[xxhash.Sum64(typeName)]
 }
 
-func (d *Document) ExtendObjectTypeDefinitionByField(objectTypeRef, fieldRef int) {
+func (d *Document) ExtendObjectTypeDefinitionByFieldDefinition(objectTypeDefinition ObjectTypeDefinition, fieldRef int) {
 	// TODO: implement
 	return
 }
 
-func (d *Document) ExtendObjectTypeDefinitionByDirective(objectTypeRef, directiveRef int) {
+func (d *Document) ExtendObjectTypeDefinitionByDirective(objectTypeDefinition ObjectTypeDefinition, directiveRef int) {
 	// TODO: implement
 	return
 }

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -456,6 +456,11 @@ func (d *Document) FieldDefinitionTypeNode(ref int) Node {
 	return d.Index.Nodes[xxhash.Sum64(typeName)]
 }
 
+func (d *Document) ExtendTypeByField(ref int) {
+	// TODO: implement
+	return
+}
+
 func (d *Document) NodeFieldDefinitions(node Node) []int {
 	switch node.Kind {
 	case NodeKindObjectTypeDefinition:

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -470,14 +470,14 @@ func (d *Document) ExtendObjectTypeDefinitionByObjectTypeExtension(objectTypeDef
 	d.Index.MergedTypeExtensions = append(d.Index.MergedTypeExtensions, Node{Ref: objectTypeExtensionRef, Kind: NodeKindObjectTypeExtension})
 }
 
-func (d *Document) RemoveMergedTypeExtensions () {
+func (d *Document) RemoveMergedTypeExtensions() {
 	for _, node := range d.Index.MergedTypeExtensions {
 		d.RemoveRootNode(node)
 	}
 }
 
 func (d *Document) RemoveRootNode(node Node) {
-	for i, _ := range d.RootNodes {
+	for i := range d.RootNodes {
 		if d.RootNodes[i] == node {
 			d.RootNodes = append(d.RootNodes[:i], d.RootNodes[i+1:]...)
 			return

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -456,12 +456,12 @@ func (d *Document) FieldDefinitionTypeNode(ref int) Node {
 	return d.Index.Nodes[xxhash.Sum64(typeName)]
 }
 
-func (d *Document) ExtendObjectTypeByField(objectTypeRef, fieldRef int) {
+func (d *Document) ExtendObjectTypeDefinitionByField(objectTypeRef, fieldRef int) {
 	// TODO: implement
 	return
 }
 
-func (d *Document) ExtendObjectTypeByDirective(objectTypeRef, directiveRef int) {
+func (d *Document) ExtendObjectTypeDefinitionByDirective(objectTypeRef, directiveRef int) {
 	// TODO: implement
 	return
 }

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -456,14 +456,33 @@ func (d *Document) FieldDefinitionTypeNode(ref int) Node {
 	return d.Index.Nodes[xxhash.Sum64(typeName)]
 }
 
-func (d *Document) ExtendObjectTypeDefinitionByFieldDefinition(objectTypeDefinition ObjectTypeDefinition, fieldRef int) {
-	// TODO: implement
-	return
+func (d *Document) ExtendObjectTypeDefinitionByObjectTypeExtension(objectTypeDefinitionRef, objectTypeExtensionRef int) {
+	if d.ObjectTypeExtensionHasFieldDefinitions(objectTypeExtensionRef) {
+		d.ObjectTypeDefinitions[objectTypeDefinitionRef].FieldsDefinition.Refs = append(d.ObjectTypeDefinitions[objectTypeDefinitionRef].FieldsDefinition.Refs, d.ObjectTypeExtensions[objectTypeExtensionRef].FieldsDefinition.Refs...)
+		d.ObjectTypeDefinitions[objectTypeDefinitionRef].HasFieldDefinitions = true
+	}
+
+	if d.ObjectTypeExtensionHasDirectives(objectTypeExtensionRef) {
+		d.ObjectTypeDefinitions[objectTypeDefinitionRef].Directives.Refs = append(d.ObjectTypeDefinitions[objectTypeDefinitionRef].Directives.Refs, d.ObjectTypeExtensions[objectTypeExtensionRef].Directives.Refs...)
+		d.ObjectTypeDefinitions[objectTypeDefinitionRef].HasDirectives = true
+	}
+
+	d.Index.MergedTypeExtensions = append(d.Index.MergedTypeExtensions, Node{Ref: objectTypeExtensionRef, Kind: NodeKindObjectTypeExtension})
 }
 
-func (d *Document) ExtendObjectTypeDefinitionByDirective(objectTypeDefinition ObjectTypeDefinition, directiveRef int) {
-	// TODO: implement
-	return
+func (d *Document) RemoveMergedTypeExtensions () {
+	for _, node := range d.Index.MergedTypeExtensions {
+		d.RemoveRootNode(node)
+	}
+}
+
+func (d *Document) RemoveRootNode(node Node) {
+	for i, _ := range d.RootNodes {
+		if d.RootNodes[i] == node {
+			d.RootNodes = append(d.RootNodes[:i], d.RootNodes[i+1:]...)
+			return
+		}
+	}
 }
 
 func (d *Document) NodeFieldDefinitions(node Node) []int {
@@ -1673,6 +1692,14 @@ func (d *Document) ObjectTypeExtensionNameBytes(ref int) ByteSlice {
 
 func (d *Document) ObjectTypeExtensionNameString(ref int) string {
 	return unsafebytes.BytesToString(d.Input.ByteSlice(d.ObjectTypeExtensions[ref].Name))
+}
+
+func (d *Document) ObjectTypeExtensionHasFieldDefinitions(ref int) bool {
+	return d.ObjectTypeExtensions[ref].HasFieldDefinitions
+}
+
+func (d *Document) ObjectTypeExtensionHasDirectives(ref int) bool {
+	return d.ObjectTypeExtensions[ref].HasDirectives
 }
 
 type InputValueDefinition struct {

--- a/pkg/ast/index.go
+++ b/pkg/ast/index.go
@@ -7,7 +7,7 @@ type Index struct {
 	SubscriptionTypeName    ByteSlice
 	Nodes                   map[uint64]Node
 	ReplacedFragmentSpreads []int
-	MergedTypeExtensions []Node
+	MergedTypeExtensions    []Node
 }
 
 func (i *Index) Reset() {
@@ -15,6 +15,7 @@ func (i *Index) Reset() {
 	i.MutationTypeName = i.MutationTypeName[:0]
 	i.SubscriptionTypeName = i.SubscriptionTypeName[:0]
 	i.ReplacedFragmentSpreads = i.ReplacedFragmentSpreads[:0]
+	i.MergedTypeExtensions = i.MergedTypeExtensions[:0]
 	for j := range i.Nodes {
 		delete(i.Nodes, j)
 	}

--- a/pkg/ast/index.go
+++ b/pkg/ast/index.go
@@ -7,6 +7,7 @@ type Index struct {
 	SubscriptionTypeName    ByteSlice
 	Nodes                   map[uint64]Node
 	ReplacedFragmentSpreads []int
+	MergedTypeExtensions []Node
 }
 
 func (i *Index) Reset() {

--- a/pkg/astnormalization/astnormalization_test.go
+++ b/pkg/astnormalization/astnormalization_test.go
@@ -143,7 +143,34 @@ var run = func(normalizeFunc registerNormalizeFunc, definition, operation, expec
 	expectedOutputDocument := unsafeparser.ParseGraphqlDocumentString(expectedOutput)
 	report := operationreport.Report{}
 	walker := astvisitor.NewWalker(48)
+
 	normalizeFunc(&walker)
+
+	walker.Walk(&operationDocument, &definitionDocument, &report)
+
+	if report.HasErrors() {
+		panic(report.Error())
+	}
+
+	got := mustString(astprinter.PrintString(&operationDocument, &definitionDocument))
+	want := mustString(astprinter.PrintString(&expectedOutputDocument, &definitionDocument))
+
+	if want != got {
+		panic(fmt.Errorf("\nwant:\n%s\ngot:\n%s", want, got))
+	}
+}
+
+func runMany(definition, operation, expectedOutput string, normalizeFuncs ...registerNormalizeFunc) {
+
+	definitionDocument := unsafeparser.ParseGraphqlDocumentString(definition)
+	operationDocument := unsafeparser.ParseGraphqlDocumentString(operation)
+	expectedOutputDocument := unsafeparser.ParseGraphqlDocumentString(expectedOutput)
+	report := operationreport.Report{}
+	walker := astvisitor.NewWalker(48)
+
+	for _, normalizeFunc := range normalizeFuncs {
+		normalizeFunc(&walker)
+	}
 
 	walker.Walk(&operationDocument, &definitionDocument, &report)
 

--- a/pkg/astnormalization/astnormalization_test.go
+++ b/pkg/astnormalization/astnormalization_test.go
@@ -161,29 +161,13 @@ var run = func(normalizeFunc registerNormalizeFunc, definition, operation, expec
 }
 
 func runMany(definition, operation, expectedOutput string, normalizeFuncs ...registerNormalizeFunc) {
-
-	definitionDocument := unsafeparser.ParseGraphqlDocumentString(definition)
-	operationDocument := unsafeparser.ParseGraphqlDocumentString(operation)
-	expectedOutputDocument := unsafeparser.ParseGraphqlDocumentString(expectedOutput)
-	report := operationreport.Report{}
-	walker := astvisitor.NewWalker(48)
-
-	for _, normalizeFunc := range normalizeFuncs {
-		normalizeFunc(&walker)
+	var runManyNormalizers = func(walker *astvisitor.Walker) {
+		for _, normalizeFunc := range normalizeFuncs {
+			normalizeFunc(walker)
+		}
 	}
 
-	walker.Walk(&operationDocument, &definitionDocument, &report)
-
-	if report.HasErrors() {
-		panic(report.Error())
-	}
-
-	got := mustString(astprinter.PrintString(&operationDocument, &definitionDocument))
-	want := mustString(astprinter.PrintString(&expectedOutputDocument, &definitionDocument))
-
-	if want != got {
-		panic(fmt.Errorf("\nwant:\n%s\ngot:\n%s", want, got))
-	}
+	run(runManyNormalizers, definition, operation, expectedOutput)
 }
 
 const testOperation = `	

--- a/pkg/astnormalization/object_type_extending.go
+++ b/pkg/astnormalization/object_type_extending.go
@@ -1,0 +1,15 @@
+package astnormalization
+
+import (
+	// "github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+)
+
+func extendObjectType(walker *astvisitor.Walker) {
+	// visitor := extendObjectTypeVisitor{
+	// 	Walker: walker,
+	// }
+	// walker.RegisterEnterDocumentVisitor(&visitor)
+	// walker.RegisterEnterSelectionSetVisitor(&visitor)
+	return
+}

--- a/pkg/astnormalization/object_type_extending.go
+++ b/pkg/astnormalization/object_type_extending.go
@@ -1,15 +1,31 @@
 package astnormalization
 
 import (
-	// "github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
 	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
 )
 
-func extendObjectType(walker *astvisitor.Walker) {
-	// visitor := extendObjectTypeVisitor{
-	// 	Walker: walker,
-	// }
-	// walker.RegisterEnterDocumentVisitor(&visitor)
-	// walker.RegisterEnterSelectionSetVisitor(&visitor)
+func extendObjectTypeDefinition(walker *astvisitor.Walker) {
+	visitor := extendObjectTypeDefinitionVisitor{
+		Walker: walker,
+	}
+	walker.RegisterObjectTypeDefinitionVisitor(&visitor)
+	return
+}
+
+type extendObjectTypeDefinitionVisitor struct {
+	*astvisitor.Walker
+	operation *ast.Document
+}
+
+func (e *extendObjectTypeDefinitionVisitor) EnterDocument(operation, definition *ast.Document) {
+	e.operation = operation
+}
+
+func (e *extendObjectTypeDefinitionVisitor) EnterObjectTypeDefinition(ref int) {
+	return
+}
+
+func (e *extendObjectTypeDefinitionVisitor) LeaveObjectTypeDefinition(ref int) {
 	return
 }

--- a/pkg/astnormalization/object_type_extending.go
+++ b/pkg/astnormalization/object_type_extending.go
@@ -9,7 +9,7 @@ func extendObjectTypeDefinition(walker *astvisitor.Walker) {
 	visitor := extendObjectTypeDefinitionVisitor{
 		Walker: walker,
 	}
-	walker.RegisterObjectTypeDefinitionVisitor(&visitor)
+	walker.RegisterEnterObjectTypeExtensionVisitor(&visitor)
 	return
 }
 
@@ -22,10 +22,6 @@ func (e *extendObjectTypeDefinitionVisitor) EnterDocument(operation, definition 
 	e.operation = operation
 }
 
-func (e *extendObjectTypeDefinitionVisitor) EnterObjectTypeDefinition(ref int) {
-	return
-}
-
-func (e *extendObjectTypeDefinitionVisitor) LeaveObjectTypeDefinition(ref int) {
+func (e *extendObjectTypeDefinitionVisitor) EnterObjectTypeExtension(ref int) {
 	return
 }

--- a/pkg/astnormalization/object_type_extending.go
+++ b/pkg/astnormalization/object_type_extending.go
@@ -23,5 +23,20 @@ func (e *extendObjectTypeDefinitionVisitor) EnterDocument(operation, definition 
 }
 
 func (e *extendObjectTypeDefinitionVisitor) EnterObjectTypeExtension(ref int) {
+
+	extension := e.operation.ObjectTypeExtensions[ref]
+
+	if extension.HasFieldDefinitions {
+		for fieldDefinitionRef, _ := range extension.FieldsDefinition.Refs {
+			e.operation.ExtendObjectTypeDefinitionByFieldDefinition(extension.ObjectTypeDefinition, fieldDefinitionRef)
+		}
+	}
+
+	if extension.HasDirectives {
+		for directiveRef, _ := range extension.Directives.Refs {
+			e.operation.ExtendObjectTypeDefinitionByDirective(extension.ObjectTypeDefinition, directiveRef)
+		}
+	}
+
 	return
 }

--- a/pkg/astnormalization/object_type_extending_test.go
+++ b/pkg/astnormalization/object_type_extending_test.go
@@ -15,6 +15,10 @@ func TestExtendObjectType(t *testing.T) {
 					type Dog {
 						name: String
 						favoriteToy: string
-					}`)
+					}
+					extend type Dog {
+						favoriteToy: String
+					}
+					`)
 	})
 }

--- a/pkg/astnormalization/object_type_extending_test.go
+++ b/pkg/astnormalization/object_type_extending_test.go
@@ -14,7 +14,7 @@ func TestExtendObjectType(t *testing.T) {
 					 `, `
 					type Dog {
 						name: String
-						favoriteToy: string
+						favoriteToy: String
 					}
 					extend type Dog {
 						favoriteToy: String
@@ -26,12 +26,67 @@ func TestExtendObjectType(t *testing.T) {
 					type Cat {
 						name: String
 					}
-					extend type Cat @deprecated("not as cool as dogs")
+					extend type Cat @deprecated(reason: "not as cool as dogs")
 					 `, `
-					type Cat @deprecated("not as cool as dogs") {
+					type Cat @deprecated(reason: "not as cool as dogs") {
 						name: String
 					}
-					extend type Cat @deprecated("not as cool as dogs")
+					extend type Cat @deprecated(reason: "not as cool as dogs")
+					`)
+	})
+	t.Run("extend object type by multiple field", func(t *testing.T) {
+		run(extendObjectTypeDefinition, testDefinition, `
+					type Dog {
+						name: String
+					}
+					extend type Dog {
+						favoriteToy: String
+						breed: String
+					}
+					 `, `
+					type Dog {
+						name: String
+						favoriteToy: String
+						breed: String
+					}
+					extend type Dog {
+						favoriteToy: String
+						breed: String
+					}
+					`)
+	})
+	t.Run("extend object type by multiple directives", func(t *testing.T) {
+		run(extendObjectTypeDefinition, testDefinition, `
+					type Cat {
+						name: String
+					}
+					extend type Cat @deprecated(reason: "not as cool as dogs") @skip(if: false)
+					 `, `
+					type Cat @deprecated(reason: "not as cool as dogs") @skip(if: false) {
+						name: String
+					}
+					extend type Cat @deprecated(reason: "not as cool as dogs") @skip(if: false)
+					`)
+	})
+	t.Run("extend object type by complex extends", func(t *testing.T) {
+		run(extendObjectTypeDefinition, testDefinition, `
+					type Cat {
+						name: String
+					}
+					extend type Cat @deprecated(reason: "not as cool as dogs") @skip(if: false) {
+						age: Int
+						breed: String
+					}
+					 `, `
+					type Cat @deprecated(reason: "not as cool as dogs") @skip(if: false) {
+						name: String
+						age: Int
+						breed: String
+					}
+					extend type Cat @deprecated(reason: "not as cool as dogs") @skip(if: false) {
+						age: Int
+						breed: String
+					}
 					`)
 	})
 }

--- a/pkg/astnormalization/object_type_extending_test.go
+++ b/pkg/astnormalization/object_type_extending_test.go
@@ -1,0 +1,20 @@
+package astnormalization
+
+import "testing"
+
+func TestExtendObjectType(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		run(extendObjectType, testDefinition, `
+					type Dog {
+						name: String
+					}
+					extend type Dog {
+						favoriteToy: String
+					}
+					 `, `
+					type Dog {
+						name: String
+						favoriteToy: string
+					}`)
+	})
+}

--- a/pkg/astnormalization/object_type_extending_test.go
+++ b/pkg/astnormalization/object_type_extending_test.go
@@ -3,8 +3,8 @@ package astnormalization
 import "testing"
 
 func TestExtendObjectType(t *testing.T) {
-	t.Run("simple", func(t *testing.T) {
-		run(extendObjectType, testDefinition, `
+	t.Run("extend simple object type by field", func(t *testing.T) {
+		run(extendObjectTypeDefinition, testDefinition, `
 					type Dog {
 						name: String
 					}
@@ -19,6 +19,19 @@ func TestExtendObjectType(t *testing.T) {
 					extend type Dog {
 						favoriteToy: String
 					}
+					`)
+	})
+	t.Run("extend simple object type by directive", func(t *testing.T) {
+		run(extendObjectTypeDefinition, testDefinition, `
+					type Cat {
+						name: String
+					}
+					extend type Cat @deprecated("not as cool as dogs")
+					 `, `
+					type Cat @deprecated("not as cool as dogs") {
+						name: String
+					}
+					extend type Cat @deprecated("not as cool as dogs")
 					`)
 	})
 }

--- a/pkg/astnormalization/remove_type_extensions.go
+++ b/pkg/astnormalization/remove_type_extensions.go
@@ -1,0 +1,21 @@
+package astnormalization
+
+import (
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+)
+
+func removeMergedTypeExtensions(walker *astvisitor.Walker) {
+	visitor := removeMergedTypeExtensionsVisitor{
+		Walker: walker,
+	}
+	walker.RegisterLeaveDocumentVisitor(&visitor)
+}
+
+type removeMergedTypeExtensionsVisitor struct {
+	*astvisitor.Walker
+}
+
+func (r *removeMergedTypeExtensionsVisitor) LeaveDocument(operation, definition *ast.Document) {
+	operation.RemoveMergedTypeExtensions()
+}

--- a/pkg/astnormalization/remove_type_extensions_test.go
+++ b/pkg/astnormalization/remove_type_extensions_test.go
@@ -1,0 +1,55 @@
+package astnormalization
+
+import "testing"
+
+func TestRemoveTypeExtensions(t *testing.T) {
+	t.Run("remove single type extension of fieldDefinition", func(t *testing.T) {
+		runMany(testDefinition, `
+					type Dog {
+						name: String
+					}
+					extend type Dog {
+						favoriteToy: String
+					}
+					 `, `
+					type Dog {
+						name: String
+						favoriteToy: String
+					}
+					`,
+			extendObjectTypeDefinition,
+			removeMergedTypeExtensions)
+	})
+	t.Run("remove single type extension of directive", func(t *testing.T) {
+		runMany(testDefinition, `
+					type Cat {
+						name: String
+					}
+					extend type Cat @deprecated(reason: "not as cool as dogs")
+					 `, `
+					type Cat @deprecated(reason: "not as cool as dogs") {
+						name: String
+					}
+					`,
+			extendObjectTypeDefinition,
+			removeMergedTypeExtensions)
+	})
+	t.Run("remove multiple type extensions at once", func(t *testing.T) {
+		runMany(testDefinition, `
+					type Cat {
+						name: String
+					}
+					extend type Cat @deprecated(reason: "not as cool as dogs")
+					extend type Cat {
+						age: Int
+					}
+					 `, `
+					type Cat @deprecated(reason: "not as cool as dogs") {
+						name: String
+						age: Int
+					}
+					`,
+			extendObjectTypeDefinition,
+			removeMergedTypeExtensions)
+	})
+}


### PR DESCRIPTION
This PR will implement the ast_normalization functionality to extend object types by ObjectTypeExtensions and the extension removal function which is responsible for removing merged extensions.
Note that removeMergedTypeExtensions' test will be expanded as new types of extension merging are implemented.