### PR TITLE
normalization of type extensions

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -456,6 +456,20 @@ func (d *Document) FieldDefinitionTypeNode(ref int) Node {
 	return d.Index.Nodes[xxhash.Sum64(typeName)]
 }
 
+func (d *Document) ExtendInterfaceTypeDefinitionByInterfaceTypeExtension(interfaceTypeDefinitionRef, interfaceTypeExtensionRef int) {
+	if d.InterfaceTypeExtensionHasFieldDefinitions(interfaceTypeExtensionRef) {
+		d.InterfaceTypeDefinitions[interfaceTypeDefinitionRef].FieldsDefinition.Refs = append(d.InterfaceTypeDefinitions[interfaceTypeDefinitionRef].FieldsDefinition.Refs, d.InterfaceTypeExtensions[interfaceTypeExtensionRef].FieldsDefinition.Refs...)
+		d.InterfaceTypeDefinitions[interfaceTypeDefinitionRef].HasFieldDefinitions = true
+	}
+
+	if d.InterfaceTypeExtensionHasDirectives(interfaceTypeExtensionRef) {
+		d.InterfaceTypeDefinitions[interfaceTypeDefinitionRef].Directives.Refs = append(d.InterfaceTypeDefinitions[interfaceTypeDefinitionRef].Directives.Refs, d.InterfaceTypeExtensions[interfaceTypeExtensionRef].Directives.Refs...)
+		d.InterfaceTypeDefinitions[interfaceTypeDefinitionRef].HasDirectives = true
+	}
+
+	d.Index.MergedTypeExtensions = append(d.Index.MergedTypeExtensions, Node{Ref: interfaceTypeExtensionRef, Kind: NodeKindInterfaceTypeExtension})
+}
+
 func (d *Document) ExtendObjectTypeDefinitionByObjectTypeExtension(objectTypeDefinitionRef, objectTypeExtensionRef int) {
 	if d.ObjectTypeExtensionHasFieldDefinitions(objectTypeExtensionRef) {
 		d.ObjectTypeDefinitions[objectTypeDefinitionRef].FieldsDefinition.Refs = append(d.ObjectTypeDefinitions[objectTypeDefinitionRef].FieldsDefinition.Refs, d.ObjectTypeExtensions[objectTypeExtensionRef].FieldsDefinition.Refs...)
@@ -1999,6 +2013,14 @@ type InterfaceTypeDefinition struct {
 	Directives          DirectiveList // optional, e.g. @foo
 	HasFieldDefinitions bool
 	FieldsDefinition    FieldDefinitionList // optional, e.g. { name: String }
+}
+
+func (d *Document) InterfaceTypeExtensionHasDirectives(ref int) bool {
+	return d.InterfaceTypeExtensions[ref].HasDirectives
+}
+
+func (d *Document) InterfaceTypeExtensionHasFieldDefinitions(ref int) bool {
+	return d.InterfaceTypeExtensions[ref].HasFieldDefinitions
 }
 
 func (d *Document) InterfaceTypeDefinitionNameBytes(ref int) ByteSlice {

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -507,6 +507,20 @@ func (d *Document) ExtendEnumTypeDefinitionByEnumTypeExtension(enumTypeDefinitio
 	d.Index.MergedTypeExtensions = append(d.Index.MergedTypeExtensions, Node{Ref: enumTypeExtensionRef, Kind: NodeKindEnumTypeExtension})
 }
 
+func (d *Document) ExtendInputObjectTypeDefinitionByInputObjectTypeExtension(inputObjectTypeDefinitionRef, inputObjectTypeExtensionRef int) {
+	if d.InputObjectTypeExtensionHasDirectives(inputObjectTypeExtensionRef) {
+		d.InputObjectTypeDefinitions[inputObjectTypeDefinitionRef].Directives.Refs = append(d.InputObjectTypeDefinitions[inputObjectTypeDefinitionRef].Directives.Refs, d.InputObjectTypeExtensions[inputObjectTypeExtensionRef].Directives.Refs...)
+		d.InputObjectTypeDefinitions[inputObjectTypeDefinitionRef].HasDirectives = true
+	}
+
+	if d.InputObjectTypeExtensionHasInputFieldsDefinition(inputObjectTypeExtensionRef) {
+		d.InputObjectTypeDefinitions[inputObjectTypeDefinitionRef].InputFieldsDefinition.Refs = append(d.InputObjectTypeDefinitions[inputObjectTypeDefinitionRef].InputFieldsDefinition.Refs, d.InputObjectTypeExtensions[inputObjectTypeExtensionRef].InputFieldsDefinition.Refs...)
+		d.InputObjectTypeDefinitions[inputObjectTypeDefinitionRef].HasInputFieldsDefinitions = true
+	}
+
+	d.Index.MergedTypeExtensions = append(d.Index.MergedTypeExtensions, Node{Ref: inputObjectTypeExtensionRef, Kind: NodeKindInputObjectTypeExtension})
+}
+
 func (d *Document) RemoveMergedTypeExtensions() {
 	for _, node := range d.Index.MergedTypeExtensions {
 		d.RemoveRootNode(node)
@@ -1890,6 +1904,14 @@ type InputObjectTypeDefinition struct {
 	Directives                DirectiveList // optional, e.g. @foo
 	HasInputFieldsDefinitions bool
 	InputFieldsDefinition     InputValueDefinitionList // e.g. x:Float
+}
+
+func (d *Document) InputObjectTypeExtensionHasDirectives(ref int) bool {
+	return d.InputObjectTypeExtensions[ref].HasDirectives
+}
+
+func (d *Document) InputObjectTypeExtensionHasInputFieldsDefinition(ref int) bool {
+	return d.InputObjectTypeDefinitions[ref].HasInputFieldsDefinitions
 }
 
 func (d *Document) InputObjectTypeDefinitionNameBytes(ref int) ByteSlice {

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -479,6 +479,20 @@ func (d *Document) ExtendScalarTypeDefinitionByScalarTypeExtension(scalarTypeDef
 	d.Index.MergedTypeExtensions = append(d.Index.MergedTypeExtensions, Node{Ref: scalarTypeExtensionRef, Kind: NodeKindScalarTypeExtension})
 }
 
+func (d *Document) ExtendUnionTypeDefinitionByUnionTypeExtension(unionTypeDefinitionRef, unionTypeExtensionRef int) {
+	if d.UnionTypeExtensionHasDirectives(unionTypeExtensionRef) {
+		d.UnionTypeDefinitions[unionTypeDefinitionRef].Directives.Refs = append(d.UnionTypeDefinitions[unionTypeDefinitionRef].Directives.Refs, d.UnionTypeExtensions[unionTypeExtensionRef].Directives.Refs...)
+		d.UnionTypeDefinitions[unionTypeDefinitionRef].HasDirectives = true
+	}
+
+	if d.UnionTypeExtensionHasUnionMemberTypes(unionTypeExtensionRef) {
+		d.UnionTypeDefinitions[unionTypeDefinitionRef].UnionMemberTypes.Refs = append(d.UnionTypeDefinitions[unionTypeDefinitionRef].UnionMemberTypes.Refs, d.UnionTypeExtensions[unionTypeExtensionRef].UnionMemberTypes.Refs...)
+		d.UnionTypeDefinitions[unionTypeDefinitionRef].HasUnionMemberTypes = true
+	}
+
+	d.Index.MergedTypeExtensions = append(d.Index.MergedTypeExtensions, Node{Ref: unionTypeExtensionRef, Kind: NodeKindUnionTypeExtension})
+}
+
 func (d *Document) RemoveMergedTypeExtensions() {
 	for _, node := range d.Index.MergedTypeExtensions {
 		d.RemoveRootNode(node)
@@ -2053,6 +2067,10 @@ type UnionTypeExtension struct {
 
 func (d *Document) UnionTypeExtensionHasDirectives(ref int) bool {
 	return d.UnionTypeExtensions[ref].HasDirectives
+}
+
+func (d *Document) UnionTypeExtensionHasUnionMemberTypes(ref int) bool {
+	return d.UnionTypeExtensions[ref].HasUnionMemberTypes
 }
 
 func (d *Document) UnionTypeExtensionNameBytes(ref int) ByteSlice {

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -493,6 +493,20 @@ func (d *Document) ExtendUnionTypeDefinitionByUnionTypeExtension(unionTypeDefini
 	d.Index.MergedTypeExtensions = append(d.Index.MergedTypeExtensions, Node{Ref: unionTypeExtensionRef, Kind: NodeKindUnionTypeExtension})
 }
 
+func (d *Document) ExtendEnumTypeDefinitionByEnumTypeExtension(enumTypeDefinitionRef, enumTypeExtensionRef int) {
+	if d.EnumTypeExtensionHasDirectives(enumTypeExtensionRef) {
+		d.EnumTypeDefinitions[enumTypeDefinitionRef].Directives.Refs = append(d.EnumTypeDefinitions[enumTypeDefinitionRef].Directives.Refs, d.EnumTypeExtensions[enumTypeExtensionRef].Directives.Refs...)
+		d.EnumTypeDefinitions[enumTypeDefinitionRef].HasDirectives = true
+	}
+
+	if d.EnumTypeDefinitionHasEnumValueDefinition(enumTypeExtensionRef) {
+		d.EnumTypeDefinitions[enumTypeDefinitionRef].EnumValuesDefinition.Refs = append(d.EnumTypeDefinitions[enumTypeDefinitionRef].EnumValuesDefinition.Refs, d.EnumTypeExtensions[enumTypeExtensionRef].EnumValuesDefinition.Refs...)
+		d.EnumTypeDefinitions[enumTypeDefinitionRef].HasEnumValuesDefinitions = true
+	}
+
+	d.Index.MergedTypeExtensions = append(d.Index.MergedTypeExtensions, Node{Ref: enumTypeExtensionRef, Kind: NodeKindEnumTypeExtension})
+}
+
 func (d *Document) RemoveMergedTypeExtensions() {
 	for _, node := range d.Index.MergedTypeExtensions {
 		d.RemoveRootNode(node)
@@ -2101,6 +2115,10 @@ type EnumTypeDefinition struct {
 
 func (d *Document) EnumTypeDefinitionHasDirectives(ref int) bool {
 	return d.EnumTypeDefinitions[ref].HasDirectives
+}
+
+func (d *Document) EnumTypeDefinitionHasEnumValueDefinition(ref int) bool {
+	return d.EnumTypeDefinitions[ref].HasEnumValuesDefinitions
 }
 
 func (d *Document) EnumTypeDefinitionNameBytes(ref int) ByteSlice {

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -515,7 +515,7 @@ func (d *Document) ExtendEnumTypeDefinitionByEnumTypeExtension(enumTypeDefinitio
 
 	if d.EnumTypeDefinitionHasEnumValueDefinition(enumTypeExtensionRef) {
 		d.EnumTypeDefinitions[enumTypeDefinitionRef].EnumValuesDefinition.Refs = append(d.EnumTypeDefinitions[enumTypeDefinitionRef].EnumValuesDefinition.Refs, d.EnumTypeExtensions[enumTypeExtensionRef].EnumValuesDefinition.Refs...)
-		d.EnumTypeDefinitions[enumTypeDefinitionRef].HasEnumValuesDefinitions = true
+		d.EnumTypeDefinitions[enumTypeDefinitionRef].HasEnumValuesDefinition = true
 	}
 
 	d.Index.MergedTypeExtensions = append(d.Index.MergedTypeExtensions, Node{Ref: enumTypeExtensionRef, Kind: NodeKindEnumTypeExtension})
@@ -529,7 +529,7 @@ func (d *Document) ExtendInputObjectTypeDefinitionByInputObjectTypeExtension(inp
 
 	if d.InputObjectTypeExtensionHasInputFieldsDefinition(inputObjectTypeExtensionRef) {
 		d.InputObjectTypeDefinitions[inputObjectTypeDefinitionRef].InputFieldsDefinition.Refs = append(d.InputObjectTypeDefinitions[inputObjectTypeDefinitionRef].InputFieldsDefinition.Refs, d.InputObjectTypeExtensions[inputObjectTypeExtensionRef].InputFieldsDefinition.Refs...)
-		d.InputObjectTypeDefinitions[inputObjectTypeDefinitionRef].HasInputFieldsDefinitions = true
+		d.InputObjectTypeDefinitions[inputObjectTypeDefinitionRef].HasInputFieldsDefinition = true
 	}
 
 	d.Index.MergedTypeExtensions = append(d.Index.MergedTypeExtensions, Node{Ref: inputObjectTypeExtensionRef, Kind: NodeKindInputObjectTypeExtension})
@@ -1911,13 +1911,13 @@ type DefaultValue struct {
 }
 
 type InputObjectTypeDefinition struct {
-	Description               Description        // optional, describes the input type
-	InputLiteral              position.Position  // input
-	Name                      ByteSliceReference // name of the input type
-	HasDirectives             bool
-	Directives                DirectiveList // optional, e.g. @foo
-	HasInputFieldsDefinitions bool
-	InputFieldsDefinition     InputValueDefinitionList // e.g. x:Float
+	Description              Description        // optional, describes the input type
+	InputLiteral             position.Position  // input
+	Name                     ByteSliceReference // name of the input type
+	HasDirectives            bool
+	Directives               DirectiveList // optional, e.g. @foo
+	HasInputFieldsDefinition bool
+	InputFieldsDefinition    InputValueDefinitionList // e.g. x:Float
 }
 
 func (d *Document) InputObjectTypeExtensionHasDirectives(ref int) bool {
@@ -1925,7 +1925,7 @@ func (d *Document) InputObjectTypeExtensionHasDirectives(ref int) bool {
 }
 
 func (d *Document) InputObjectTypeExtensionHasInputFieldsDefinition(ref int) bool {
-	return d.InputObjectTypeDefinitions[ref].HasInputFieldsDefinitions
+	return d.InputObjectTypeDefinitions[ref].HasInputFieldsDefinition
 }
 
 func (d *Document) InputObjectTypeDefinitionNameBytes(ref int) ByteSlice {
@@ -2148,13 +2148,13 @@ func (d *Document) UnionTypeExtensionNameString(ref int) string {
 //  WEST
 //}
 type EnumTypeDefinition struct {
-	Description              Description        // optional, describes enum
-	EnumLiteral              position.Position  // enum
-	Name                     ByteSliceReference // e.g. Direction
-	HasDirectives            bool
-	Directives               DirectiveList // optional, e.g. @foo
-	HasEnumValuesDefinitions bool
-	EnumValuesDefinition     EnumValueDefinitionList // optional, e.g. { NORTH EAST }
+	Description             Description        // optional, describes enum
+	EnumLiteral             position.Position  // enum
+	Name                    ByteSliceReference // e.g. Direction
+	HasDirectives           bool
+	Directives              DirectiveList // optional, e.g. @foo
+	HasEnumValuesDefinition bool
+	EnumValuesDefinition    EnumValueDefinitionList // optional, e.g. { NORTH EAST }
 }
 
 func (d *Document) EnumTypeDefinitionHasDirectives(ref int) bool {
@@ -2162,7 +2162,7 @@ func (d *Document) EnumTypeDefinitionHasDirectives(ref int) bool {
 }
 
 func (d *Document) EnumTypeDefinitionHasEnumValueDefinition(ref int) bool {
-	return d.EnumTypeDefinitions[ref].HasEnumValuesDefinitions
+	return d.EnumTypeDefinitions[ref].HasEnumValuesDefinition
 }
 
 func (d *Document) EnumTypeDefinitionNameBytes(ref int) ByteSlice {

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -470,6 +470,15 @@ func (d *Document) ExtendObjectTypeDefinitionByObjectTypeExtension(objectTypeDef
 	d.Index.MergedTypeExtensions = append(d.Index.MergedTypeExtensions, Node{Ref: objectTypeExtensionRef, Kind: NodeKindObjectTypeExtension})
 }
 
+func (d *Document) ExtendScalarTypeDefinitionByScalarTypeExtension(scalarTypeDefinitionRef, scalarTypeExtensionRef int) {
+	if d.ScalarTypeExtensionHasDirectives(scalarTypeExtensionRef) {
+		d.ScalarTypeDefinitions[scalarTypeDefinitionRef].Directives.Refs = append(d.ScalarTypeDefinitions[scalarTypeDefinitionRef].Directives.Refs, d.ScalarTypeExtensions[scalarTypeExtensionRef].Directives.Refs...)
+		d.ScalarTypeDefinitions[scalarTypeDefinitionRef].HasDirectives = true
+	}
+
+	d.Index.MergedTypeExtensions = append(d.Index.MergedTypeExtensions, Node{Ref: scalarTypeExtensionRef, Kind: NodeKindScalarTypeExtension})
+}
+
 func (d *Document) RemoveMergedTypeExtensions() {
 	for _, node := range d.Index.MergedTypeExtensions {
 		d.RemoveRootNode(node)

--- a/pkg/astnormalization/enum_type_extending.go
+++ b/pkg/astnormalization/enum_type_extending.go
@@ -1,0 +1,38 @@
+package astnormalization
+
+import (
+	"github.com/cespare/xxhash"
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+)
+
+func extendEnumTypeDefinition(walker *astvisitor.Walker) {
+	visitor := extendEnumTypeDefinitionVisitor{
+		Walker: walker,
+	}
+	walker.RegisterEnterDocumentVisitor(&visitor)
+	walker.RegisterEnterEnumTypeExtensionVisitor(&visitor)
+}
+
+type extendEnumTypeDefinitionVisitor struct {
+	*astvisitor.Walker
+	operation *ast.Document
+}
+
+func (e *extendEnumTypeDefinitionVisitor) EnterDocument(operation, definition *ast.Document) {
+	e.operation = operation
+}
+
+func (e *extendEnumTypeDefinitionVisitor) EnterEnumTypeExtension(ref int) {
+
+	baseNode, exists := e.operation.Index.Nodes[xxhash.Sum64(e.operation.EnumTypeExtensionNameBytes(ref))]
+	if !exists {
+		return
+	}
+
+	if baseNode.Kind != ast.NodeKindEnumTypeDefinition {
+		return
+	}
+
+	e.operation.ExtendEnumTypeDefinitionByEnumTypeExtension(baseNode.Ref, ref)
+}

--- a/pkg/astnormalization/enum_type_extending_test.go
+++ b/pkg/astnormalization/enum_type_extending_test.go
@@ -3,7 +3,7 @@ package astnormalization
 import "testing"
 
 func TestExtendEnumType(t *testing.T) {
-	t.Run("extend simple enum type by directive", func(t *testing.T) {
+	t.Run("extend enum type by directive", func(t *testing.T) {
 		run(extendEnumTypeDefinition, testDefinition, `
 					enum Countries {DE ES NL}
 					extend enum Countries @deprecated(reason: "some reason")
@@ -12,7 +12,7 @@ func TestExtendEnumType(t *testing.T) {
 					extend enum Countries @deprecated(reason: "some reason")
 					`)
 	})
-	t.Run("extend simple enum type by enum values", func(t *testing.T) {
+	t.Run("extend enum type by enum values", func(t *testing.T) {
 		run(extendEnumTypeDefinition, testDefinition, `
 					enum Countries {DE ES NL}
 					extend enum Countries {EN}
@@ -21,7 +21,7 @@ func TestExtendEnumType(t *testing.T) {
 					extend enum Countries {EN}
 					`)
 	})
-	t.Run("extend enum type by numtiple enum values and directives", func(t *testing.T) {
+	t.Run("extend enum type by multiple enum values and directives", func(t *testing.T) {
 		run(extendEnumTypeDefinition, testDefinition, `
 					enum Countries {DE ES NL}
 					extend enum Countries @deprecated(reason: "some reason") @skip(if: false) {EN IT}

--- a/pkg/astnormalization/enum_type_extending_test.go
+++ b/pkg/astnormalization/enum_type_extending_test.go
@@ -3,13 +3,31 @@ package astnormalization
 import "testing"
 
 func TestExtendEnumType(t *testing.T) {
-	t.Run("extend simple union type by directive", func(t *testing.T) {
+	t.Run("extend simple enum type by directive", func(t *testing.T) {
 		run(extendEnumTypeDefinition, testDefinition, `
 					enum Countries {DE ES NL}
 					extend enum Countries @deprecated(reason: "some reason")
 					 `, `
 					enum Countries @deprecated(reason: "some reason") {DE ES NL} 
 					extend enum Countries @deprecated(reason: "some reason")
+					`)
+	})
+	t.Run("extend simple enum type by enum values", func(t *testing.T) {
+		run(extendEnumTypeDefinition, testDefinition, `
+					enum Countries {DE ES NL}
+					extend enum Countries {EN}
+					 `, `
+					enum Countries {DE ES NL EN}
+					extend enum Countries {EN}
+					`)
+	})
+	t.Run("extend enum type by numtiple enum values and directives", func(t *testing.T) {
+		run(extendEnumTypeDefinition, testDefinition, `
+					enum Countries {DE ES NL}
+					extend enum Countries @deprecated(reason: "some reason") @skip(if: false) {EN IT}
+					 `, `
+					enum Countries @deprecated(reason: "some reason") @skip(if: false) {DE ES NL EN IT}
+					extend enum Countries @deprecated(reason: "some reason") @skip(if: false) {EN IT}
 					`)
 	})
 }

--- a/pkg/astnormalization/enum_type_extending_test.go
+++ b/pkg/astnormalization/enum_type_extending_test.go
@@ -1,0 +1,15 @@
+package astnormalization
+
+import "testing"
+
+func TestExtendEnumType(t *testing.T) {
+	t.Run("extend simple union type by directive", func(t *testing.T) {
+		run(extendEnumTypeDefinition, testDefinition, `
+					enum Countries {DE ES NL}
+					extend enum Countries @deprecated(reason: "some reason")
+					 `, `
+					enum Countries @deprecated(reason: "some reason") {DE ES NL} 
+					extend enum Countries @deprecated(reason: "some reason")
+					`)
+	})
+}

--- a/pkg/astnormalization/input_object_type_extending.go
+++ b/pkg/astnormalization/input_object_type_extending.go
@@ -1,0 +1,38 @@
+package astnormalization
+
+import (
+	"github.com/cespare/xxhash"
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+)
+
+func extendInputObjectTypeDefinition(walker *astvisitor.Walker) {
+	visitor := extendInputObjectTypeDefinitionVisitor{
+		Walker: walker,
+	}
+	walker.RegisterEnterDocumentVisitor(&visitor)
+	walker.RegisterEnterInputObjectTypeExtensionVisitor(&visitor)
+}
+
+type extendInputObjectTypeDefinitionVisitor struct {
+	*astvisitor.Walker
+	operation *ast.Document
+}
+
+func (e *extendInputObjectTypeDefinitionVisitor) EnterDocument(operation, definition *ast.Document) {
+	e.operation = operation
+}
+
+func (e *extendInputObjectTypeDefinitionVisitor) EnterInputObjectTypeExtension(ref int) {
+
+	baseNode, exists := e.operation.Index.Nodes[xxhash.Sum64(e.operation.InputObjectTypeExtensionNameBytes(ref))]
+	if !exists {
+		return
+	}
+
+	if baseNode.Kind != ast.NodeKindInputObjectTypeDefinition {
+		return
+	}
+
+	e.operation.ExtendInputObjectTypeDefinitionByInputObjectTypeExtension(baseNode.Ref, ref)
+}

--- a/pkg/astnormalization/input_object_type_extending_test.go
+++ b/pkg/astnormalization/input_object_type_extending_test.go
@@ -3,7 +3,7 @@ package astnormalization
 import "testing"
 
 func TestExtendInputObjectType(t *testing.T) {
-	t.Run("extend simple input object type by directive", func(t *testing.T) {
+	t.Run("extend input object type by directive", func(t *testing.T) {
 		run(extendInputObjectTypeDefinition, testDefinition, `
 					input DogSize {width: Float height: Float}
 					extend input DogSize @deprecated(reason: "some reason")
@@ -12,7 +12,7 @@ func TestExtendInputObjectType(t *testing.T) {
 					extend input DogSize @deprecated(reason: "some reason")
 					`)
 	})
-	t.Run("extend simple input object type by input fields definition", func(t *testing.T) {
+	t.Run("extend input object type by input fields definition", func(t *testing.T) {
 		run(extendInputObjectTypeDefinition, testDefinition, `
 					input DogSize {width: Float height: Float}
 					extend input DogSize {breadth: Float}

--- a/pkg/astnormalization/input_object_type_extending_test.go
+++ b/pkg/astnormalization/input_object_type_extending_test.go
@@ -1,0 +1,15 @@
+package astnormalization
+
+import "testing"
+
+func TestExtendInputObjectType(t *testing.T) {
+	t.Run("extend simple input object type by directive", func(t *testing.T) {
+		run(extendInputObjectTypeDefinition, testDefinition, `
+					input DogSize {width: Float height: Float}
+					extend input DogSize @deprecated(reason: "some reason")
+					 `, `
+					input DogSize @deprecated(reason: "some reason") {width: Float height: Float}
+					extend input DogSize @deprecated(reason: "some reason")
+					`)
+	})
+}

--- a/pkg/astnormalization/input_object_type_extending_test.go
+++ b/pkg/astnormalization/input_object_type_extending_test.go
@@ -17,7 +17,7 @@ func TestExtendInputObjectType(t *testing.T) {
 					input DogSize {width: Float height: Float}
 					extend input DogSize {breadth: Float}
 					 `, `
-input DogSize {width: Float height: Float, breadth: Float}
+					input DogSize {width: Float height: Float, breadth: Float}
 					extend input DogSize {breadth: Float}
 					`)
 	})

--- a/pkg/astnormalization/input_object_type_extending_test.go
+++ b/pkg/astnormalization/input_object_type_extending_test.go
@@ -12,6 +12,15 @@ func TestExtendInputObjectType(t *testing.T) {
 					extend input DogSize @deprecated(reason: "some reason")
 					`)
 	})
+	t.Run("extend simple input object type by input fields definition", func(t *testing.T) {
+		run(extendInputObjectTypeDefinition, testDefinition, `
+					input DogSize {width: Float height: Float}
+					extend input DogSize {breadth: Float}
+					 `, `
+input DogSize {width: Float height: Float, breadth: Float}
+					extend input DogSize {breadth: Float}
+					`)
+	})
 	t.Run("extend input object type by multiple input fields definition and directives", func(t *testing.T) {
 		run(extendInputObjectTypeDefinition, testDefinition, `
 					input DogSize {width: Float height: Float}

--- a/pkg/astnormalization/input_object_type_extending_test.go
+++ b/pkg/astnormalization/input_object_type_extending_test.go
@@ -12,4 +12,13 @@ func TestExtendInputObjectType(t *testing.T) {
 					extend input DogSize @deprecated(reason: "some reason")
 					`)
 	})
+	t.Run("extend input object type by multiple input fields definition and directives", func(t *testing.T) {
+		run(extendInputObjectTypeDefinition, testDefinition, `
+					input DogSize {width: Float height: Float}
+					extend input DogSize @deprecated(reason: "some reason") @skip(if: false) {breadth: Float weight: Float}
+					 `, `
+					input DogSize @deprecated(reason: "some reason") @skip(if: false) {width: Float height: Float breadth: Float weight: Float}
+					extend input DogSize @deprecated(reason: "some reason") @skip(if: false) {breadth: Float weight: Float}
+					`)
+	})
 }

--- a/pkg/astnormalization/interface_type_extending.go
+++ b/pkg/astnormalization/interface_type_extending.go
@@ -1,0 +1,38 @@
+package astnormalization
+
+import (
+	"github.com/cespare/xxhash"
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+)
+
+func extendInterfaceTypeDefinition(walker *astvisitor.Walker) {
+	visitor := extendInterfaceTypeDefinitionVisitor{
+		Walker: walker,
+	}
+	walker.RegisterEnterDocumentVisitor(&visitor)
+	walker.RegisterEnterInterfaceTypeExtensionVisitor(&visitor)
+}
+
+type extendInterfaceTypeDefinitionVisitor struct {
+	*astvisitor.Walker
+	operation *ast.Document
+}
+
+func (e *extendInterfaceTypeDefinitionVisitor) EnterDocument(operation, definition *ast.Document) {
+	e.operation = operation
+}
+
+func (e *extendInterfaceTypeDefinitionVisitor) EnterInterfaceTypeExtension(ref int) {
+
+	baseNode, exists := e.operation.Index.Nodes[xxhash.Sum64(e.operation.InterfaceTypeExtensionNameBytes(ref))]
+	if !exists {
+		return
+	}
+
+	if baseNode.Kind != ast.NodeKindInterfaceTypeDefinition {
+		return
+	}
+
+	e.operation.ExtendInterfaceTypeDefinitionByInterfaceTypeExtension(baseNode.Ref, ref)
+}

--- a/pkg/astnormalization/interface_type_extending_test.go
+++ b/pkg/astnormalization/interface_type_extending_test.go
@@ -1,0 +1,58 @@
+package astnormalization
+
+import "testing"
+
+func TestExtendInterfaceType(t *testing.T) {
+	t.Run("extend simple interface type by field", func(t *testing.T) {
+		run(extendInterfaceTypeDefinition, testDefinition, `
+					interface Mammal {
+						name: String
+					}
+					extend interface Mammal {
+						furType: String
+					}
+					 `, `
+					interface Mammal {
+						name: String
+						furType: String
+					}
+					extend interface Mammal {
+						furType: String
+					}
+					`)
+	})
+	t.Run("extend simple interface type by directive", func(t *testing.T) {
+		run(extendInterfaceTypeDefinition, testDefinition, `
+					interface Mammal {
+						name: String
+					}
+					extend interface Mammal @deprecated(reason: "some reason")
+					 `, `
+					interface Mammal @deprecated(reason: "some reason") {
+						name: String
+					}
+					extend interface Mammal @deprecated(reason: "some reason")
+					`)
+	})
+	t.Run("extend interface type by complex extends", func(t *testing.T) {
+		run(extendInterfaceTypeDefinition, testDefinition, `
+					interface Mammal {
+						name: String
+					}
+					extend interface Mammal @deprecated(reason: "some reason") @skip(if: false) {
+						furType: String
+						age: Int
+					}
+					 `, `
+					interface Mammal @deprecated(reason: "some reason") @skip(if: false) {
+						name: String
+						furType: String
+						age: Int
+					}
+					extend interface Mammal @deprecated(reason: "some reason") @skip(if: false) {
+						furType: String
+						age: Int
+					}
+					`)
+	})
+}

--- a/pkg/astnormalization/object_type_extending_test.go
+++ b/pkg/astnormalization/object_type_extending_test.go
@@ -3,7 +3,7 @@ package astnormalization
 import "testing"
 
 func TestExtendObjectType(t *testing.T) {
-	t.Run("extend simple object type by field", func(t *testing.T) {
+	t.Run("extend object type by field", func(t *testing.T) {
 		run(extendObjectTypeDefinition, testDefinition, `
 					type Dog {
 						name: String
@@ -21,7 +21,7 @@ func TestExtendObjectType(t *testing.T) {
 					}
 					`)
 	})
-	t.Run("extend simple object type by directive", func(t *testing.T) {
+	t.Run("extend object type by directive", func(t *testing.T) {
 		run(extendObjectTypeDefinition, testDefinition, `
 					type Cat {
 						name: String

--- a/pkg/astnormalization/remove_type_extensions_test.go
+++ b/pkg/astnormalization/remove_type_extensions_test.go
@@ -62,4 +62,14 @@ func TestRemoveTypeExtensions(t *testing.T) {
 			extendScalarTypeDefinition,
 			removeMergedTypeExtensions)
 	})
+	t.Run("remove multiple scalar type extensions", func(t *testing.T) {
+		runMany(testDefinition, `
+					union Mammal
+					extend union Mammal @deprecated(reason: "some reason") @skip(if: false) = Cat | Dog
+					 `, `
+					union Mammal @deprecated(reason: "some reason") @skip(if: false) = Cat | Dog
+					`,
+			extendUnionTypeDefinition,
+			removeMergedTypeExtensions)
+	})
 }

--- a/pkg/astnormalization/remove_type_extensions_test.go
+++ b/pkg/astnormalization/remove_type_extensions_test.go
@@ -72,4 +72,14 @@ func TestRemoveTypeExtensions(t *testing.T) {
 			extendEnumTypeDefinition,
 			removeMergedTypeExtensions)
 	})
+	t.Run("remove multiple scalar type extensions", func(t *testing.T) {
+		runMany(testDefinition, `
+					input DogSize {width: Float height: Float}
+					extend input DogSize @deprecated(reason: "some reason") @skip(if: false) {breadth: Float weight: Float}
+					 `, `
+					input DogSize @deprecated(reason: "some reason") @skip(if: false) {width: Float height: Float breadth: Float weight: Float}
+					`,
+			extendInputObjectTypeDefinition,
+			removeMergedTypeExtensions)
+	})
 }

--- a/pkg/astnormalization/remove_type_extensions_test.go
+++ b/pkg/astnormalization/remove_type_extensions_test.go
@@ -52,4 +52,14 @@ func TestRemoveTypeExtensions(t *testing.T) {
 			extendObjectTypeDefinition,
 			removeMergedTypeExtensions)
 	})
+	t.Run("remove multiple scalar type extensions", func(t *testing.T) {
+		runMany(testDefinition, `
+					scalar Coordinates
+					extend scalar Coordinates @deprecated(reason: "some reason") @skip(if: false)
+					 `, `
+					scalar Coordinates @deprecated(reason: "some reason") @skip(if: false)
+					`,
+			extendScalarTypeDefinition,
+			removeMergedTypeExtensions)
+	})
 }

--- a/pkg/astnormalization/remove_type_extensions_test.go
+++ b/pkg/astnormalization/remove_type_extensions_test.go
@@ -52,7 +52,7 @@ func TestRemoveTypeExtensions(t *testing.T) {
 			extendObjectTypeDefinition,
 			removeMergedTypeExtensions)
 	})
-	t.Run("remove multiple scalar type extensions", func(t *testing.T) {
+	t.Run("remove scalar type extensions", func(t *testing.T) {
 		runMany(testDefinition, `
 					scalar Coordinates
 					extend scalar Coordinates @deprecated(reason: "some reason") @skip(if: false)
@@ -62,7 +62,7 @@ func TestRemoveTypeExtensions(t *testing.T) {
 			extendScalarTypeDefinition,
 			removeMergedTypeExtensions)
 	})
-	t.Run("remove multiple scalar type extensions", func(t *testing.T) {
+	t.Run("remove enum type extensions", func(t *testing.T) {
 		runMany(testDefinition, `
 					enum Countries {DE ES NL}
 					extend enum Countries @deprecated(reason: "some reason") @skip(if: false) {EN IT}
@@ -72,7 +72,27 @@ func TestRemoveTypeExtensions(t *testing.T) {
 			extendEnumTypeDefinition,
 			removeMergedTypeExtensions)
 	})
-	t.Run("remove multiple scalar type extensions", func(t *testing.T) {
+	t.Run("remove union type extensions", func(t *testing.T) {
+		runMany(testDefinition, `
+					union Mammal
+					extend union Mammal @deprecated(reason: "some reason") @skip(if: false) = Cat | Dog
+					 `, `
+					union Mammal @deprecated(reason: "some reason") @skip(if: false) = Cat | Dog
+					`,
+			extendUnionTypeDefinition,
+			removeMergedTypeExtensions)
+	})
+	t.Run("remove input object type extensions", func(t *testing.T) {
+		runMany(testDefinition, `
+					input DogSize {width: Float height: Float}
+					extend input DogSize @deprecated(reason: "some reason") @skip(if: false) {breadth: Float weight: Float}
+					 `, `
+					input DogSize @deprecated(reason: "some reason") @skip(if: false) {width: Float height: Float breadth: Float weight: Float}
+					`,
+			extendInputObjectTypeDefinition,
+			removeMergedTypeExtensions)
+	})
+	t.Run("remove interface type extensions", func(t *testing.T) {
 		runMany(testDefinition, `
 					interface Mammal {
 						name: String

--- a/pkg/astnormalization/remove_type_extensions_test.go
+++ b/pkg/astnormalization/remove_type_extensions_test.go
@@ -74,12 +74,21 @@ func TestRemoveTypeExtensions(t *testing.T) {
 	})
 	t.Run("remove multiple scalar type extensions", func(t *testing.T) {
 		runMany(testDefinition, `
-					input DogSize {width: Float height: Float}
-					extend input DogSize @deprecated(reason: "some reason") @skip(if: false) {breadth: Float weight: Float}
+					interface Mammal {
+						name: String
+					}
+					extend interface Mammal @deprecated(reason: "some reason") @skip(if: false) {
+						furType: String
+						age: Int
+					}
 					 `, `
-					input DogSize @deprecated(reason: "some reason") @skip(if: false) {width: Float height: Float breadth: Float weight: Float}
+					interface Mammal @deprecated(reason: "some reason") @skip(if: false) {
+						name: String
+						furType: String
+						age: Int
+					}
 					`,
-			extendInputObjectTypeDefinition,
+			extendInterfaceTypeDefinition,
 			removeMergedTypeExtensions)
 	})
 }

--- a/pkg/astnormalization/remove_type_extensions_test.go
+++ b/pkg/astnormalization/remove_type_extensions_test.go
@@ -64,12 +64,12 @@ func TestRemoveTypeExtensions(t *testing.T) {
 	})
 	t.Run("remove multiple scalar type extensions", func(t *testing.T) {
 		runMany(testDefinition, `
-					union Mammal
-					extend union Mammal @deprecated(reason: "some reason") @skip(if: false) = Cat | Dog
+					enum Countries {DE ES NL}
+					extend enum Countries @deprecated(reason: "some reason") @skip(if: false) {EN IT}
 					 `, `
-					union Mammal @deprecated(reason: "some reason") @skip(if: false) = Cat | Dog
+					enum Countries @deprecated(reason: "some reason") @skip(if: false) {DE ES NL EN IT}
 					`,
-			extendUnionTypeDefinition,
+			extendEnumTypeDefinition,
 			removeMergedTypeExtensions)
 	})
 }

--- a/pkg/astnormalization/scalar_type_extending.go
+++ b/pkg/astnormalization/scalar_type_extending.go
@@ -1,0 +1,38 @@
+package astnormalization
+
+import (
+	"github.com/cespare/xxhash"
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+)
+
+func extendScalarTypeDefinition(walker *astvisitor.Walker) {
+	visitor := extendScalarTypeDefinitionVisitor{
+		Walker: walker,
+	}
+	walker.RegisterEnterDocumentVisitor(&visitor)
+	walker.RegisterEnterScalarTypeExtensionVisitor(&visitor)
+}
+
+type extendScalarTypeDefinitionVisitor struct {
+	*astvisitor.Walker
+	operation *ast.Document
+}
+
+func (e *extendScalarTypeDefinitionVisitor) EnterDocument(operation, definition *ast.Document) {
+	e.operation = operation
+}
+
+func (e *extendScalarTypeDefinitionVisitor) EnterScalarTypeExtension(ref int) {
+
+	baseNode, exists := e.operation.Index.Nodes[xxhash.Sum64(e.operation.ScalarTypeExtensionNameBytes(ref))]
+	if !exists {
+		return
+	}
+
+	if baseNode.Kind != ast.NodeKindScalarTypeDefinition {
+		return
+	}
+
+	e.operation.ExtendScalarTypeDefinitionByScalarTypeExtension(baseNode.Ref, ref)
+}

--- a/pkg/astnormalization/scalar_type_extending_test.go
+++ b/pkg/astnormalization/scalar_type_extending_test.go
@@ -12,4 +12,13 @@ func TestExtendScalarType(t *testing.T) {
 					extend scalar Coordinates @deprecated(reason: "some reason")
 					`)
 	})
+	t.Run("extend scalar type by multiple directives", func(t *testing.T) {
+		run(extendScalarTypeDefinition, testDefinition, `
+					scalar Coordinates
+					extend scalar Coordinates @deprecated(reason: "some reason") @skip(if: false)
+					 `, `
+					scalar Coordinates @deprecated(reason: "some reason") @skip(if: false)
+					extend scalar Coordinates @deprecated(reason: "some reason") @skip(if: false)
+					`)
+	})
 }

--- a/pkg/astnormalization/scalar_type_extending_test.go
+++ b/pkg/astnormalization/scalar_type_extending_test.go
@@ -1,0 +1,15 @@
+package astnormalization
+
+import "testing"
+
+func TestExtendScalarType(t *testing.T) {
+	t.Run("extend simple scalar type", func(t *testing.T) {
+		run(extendScalarTypeDefinition, testDefinition, `
+					scalar Coordinates
+					extend scalar Coordinates @deprecated(reason: "some reason")
+					 `, `
+					scalar Coordinates @deprecated(reason: "some reason")
+					extend scalar Coordinates @deprecated(reason: "some reason")
+					`)
+	})
+}

--- a/pkg/astnormalization/union_type_extending.go
+++ b/pkg/astnormalization/union_type_extending.go
@@ -1,0 +1,38 @@
+package astnormalization
+
+import (
+	"github.com/cespare/xxhash"
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+)
+
+func extendUnionTypeDefinition(walker *astvisitor.Walker) {
+	visitor := extendUnionTypeDefinitionVisitor{
+		Walker: walker,
+	}
+	walker.RegisterEnterDocumentVisitor(&visitor)
+	walker.RegisterEnterUnionTypeExtensionVisitor(&visitor)
+}
+
+type extendUnionTypeDefinitionVisitor struct {
+	*astvisitor.Walker
+	operation *ast.Document
+}
+
+func (e *extendUnionTypeDefinitionVisitor) EnterDocument(operation, definition *ast.Document) {
+	e.operation = operation
+}
+
+func (e *extendUnionTypeDefinitionVisitor) EnterUnionTypeExtension(ref int) {
+
+	baseNode, exists := e.operation.Index.Nodes[xxhash.Sum64(e.operation.UnionTypeExtensionNameBytes(ref))]
+	if !exists {
+		return
+	}
+
+	if baseNode.Kind != ast.NodeKindUnionTypeDefinition {
+		return
+	}
+
+	e.operation.ExtendUnionTypeDefinitionByUnionTypeExtension(baseNode.Ref, ref)
+}

--- a/pkg/astnormalization/union_type_extending_test.go
+++ b/pkg/astnormalization/union_type_extending_test.go
@@ -3,13 +3,31 @@ package astnormalization
 import "testing"
 
 func TestExtendUnionType(t *testing.T) {
-	t.Run("extend simple union type by UnionMemberType", func(t *testing.T) {
+	t.Run("extend simple union type by directive", func(t *testing.T) {
 		run(extendUnionTypeDefinition, testDefinition, `
 					union Mammal
 					extend union Mammal @deprecated(reason: "some reason")
 					 `, `
 					union Mammal @deprecated(reason: "some reason")
 					extend union Mammal @deprecated(reason: "some reason")
+					`)
+	})
+	t.Run("extend simple union type by UnionMemberType", func(t *testing.T) {
+		run(extendUnionTypeDefinition, testDefinition, `
+					union Mammal
+					extend union Mammal = Cat
+					 `, `
+					union Mammal = Cat
+					extend union Mammal = Cat
+					`)
+	})
+	t.Run("extend union by multiple directives and union members", func(t *testing.T) {
+		run(extendUnionTypeDefinition, testDefinition, `
+					union Mammal
+					extend union Mammal @deprecated(reason: "some reason") @skip(if: false) = Cat | Dog
+					 `, `
+					union Mammal @deprecated(reason: "some reason") @skip(if: false) = Cat | Dog
+					extend union Mammal @deprecated(reason: "some reason") @skip(if: false) = Cat | Dog
 					`)
 	})
 }

--- a/pkg/astnormalization/union_type_extending_test.go
+++ b/pkg/astnormalization/union_type_extending_test.go
@@ -39,4 +39,13 @@ func TestExtendUnionType(t *testing.T) {
 					extend union Mammal @deprecated(reason: "some reason") @skip(if: false) = Cat | Dog
 					`)
 	})
+	t.Run("extend union type which already has union member", func(t *testing.T) {
+		run(extendUnionTypeDefinition, testDefinition, `
+					union Mammal = Cat
+					extend union Mammal @deprecated(reason: "some reason") = Dog
+					 `, `
+					union Mammal @deprecated(reason: "some reason") = Cat | Dog
+					extend union Mammal @deprecated(reason: "some reason") = Dog
+					`)
+	})
 }

--- a/pkg/astnormalization/union_type_extending_test.go
+++ b/pkg/astnormalization/union_type_extending_test.go
@@ -3,7 +3,7 @@ package astnormalization
 import "testing"
 
 func TestExtendUnionType(t *testing.T) {
-	t.Run("extend simple union type by directive", func(t *testing.T) {
+	t.Run("extend union type by directive", func(t *testing.T) {
 		run(extendUnionTypeDefinition, testDefinition, `
 					union Mammal
 					extend union Mammal @deprecated(reason: "some reason")
@@ -12,7 +12,7 @@ func TestExtendUnionType(t *testing.T) {
 					extend union Mammal @deprecated(reason: "some reason")
 					`)
 	})
-	t.Run("extend simple union type by UnionMemberType", func(t *testing.T) {
+	t.Run("extend union type by UnionMemberType", func(t *testing.T) {
 		run(extendUnionTypeDefinition, testDefinition, `
 					union Mammal
 					extend union Mammal = Cat

--- a/pkg/astnormalization/union_type_extending_test.go
+++ b/pkg/astnormalization/union_type_extending_test.go
@@ -21,6 +21,15 @@ func TestExtendUnionType(t *testing.T) {
 					extend union Mammal = Cat
 					`)
 	})
+	t.Run("extend union type by multiple UnionMemberTypes", func(t *testing.T) {
+		run(extendUnionTypeDefinition, testDefinition, `
+					union Mammal
+					extend union Mammal = Cat | Dog
+					 `, `
+					union Mammal = Cat | Dog
+					extend union Mammal = Cat | Dog
+					`)
+	})
 	t.Run("extend union by multiple directives and union members", func(t *testing.T) {
 		run(extendUnionTypeDefinition, testDefinition, `
 					union Mammal

--- a/pkg/astnormalization/union_type_extending_test.go
+++ b/pkg/astnormalization/union_type_extending_test.go
@@ -1,0 +1,15 @@
+package astnormalization
+
+import "testing"
+
+func TestExtendUnionType(t *testing.T) {
+	t.Run("extend simple union type by UnionMemberType", func(t *testing.T) {
+		run(extendUnionTypeDefinition, testDefinition, `
+					union Mammal
+					extend union Mammal @deprecated(reason: "some reason")
+					 `, `
+					union Mammal @deprecated(reason: "some reason")
+					extend union Mammal @deprecated(reason: "some reason")
+					`)
+	})
+}

--- a/pkg/astparser/parser.go
+++ b/pkg/astparser/parser.go
@@ -1133,7 +1133,7 @@ func (p *Parser) parseInputObjectTypeDefinition(description *ast.Description) {
 	}
 	if p.peekEquals(keyword.LBRACE) {
 		inputObjectTypeDefinition.InputFieldsDefinition = p.parseInputValueDefinitionList(keyword.RBRACE)
-		inputObjectTypeDefinition.HasInputFieldsDefinitions = len(inputObjectTypeDefinition.InputFieldsDefinition.Refs) > 0
+		inputObjectTypeDefinition.HasInputFieldsDefinition = len(inputObjectTypeDefinition.InputFieldsDefinition.Refs) > 0
 	}
 	p.document.InputObjectTypeDefinitions = append(p.document.InputObjectTypeDefinitions, inputObjectTypeDefinition)
 	ref := len(p.document.InputObjectTypeDefinitions) - 1
@@ -1292,7 +1292,7 @@ func (p *Parser) parseEnumTypeDefinition(description *ast.Description) {
 	}
 	if p.peekEquals(keyword.LBRACE) {
 		enumTypeDefinition.EnumValuesDefinition = p.parseEnumValueDefinitionList()
-		enumTypeDefinition.HasEnumValuesDefinitions = len(enumTypeDefinition.EnumValuesDefinition.Refs) > 0
+		enumTypeDefinition.HasEnumValuesDefinition = len(enumTypeDefinition.EnumValuesDefinition.Refs) > 0
 	}
 	p.document.EnumTypeDefinitions = append(p.document.EnumTypeDefinitions, enumTypeDefinition)
 	ref := len(p.document.EnumTypeDefinitions) - 1
@@ -1876,7 +1876,7 @@ func (p *Parser) parseEnumTypeExtension(extend position.Position) {
 	}
 	if p.peekEquals(keyword.LBRACE) {
 		enumTypeDefinition.EnumValuesDefinition = p.parseEnumValueDefinitionList()
-		enumTypeDefinition.HasEnumValuesDefinitions = len(enumTypeDefinition.EnumValuesDefinition.Refs) > 0
+		enumTypeDefinition.HasEnumValuesDefinition = len(enumTypeDefinition.EnumValuesDefinition.Refs) > 0
 	}
 	enumTypeExtension := ast.EnumTypeExtension{
 		ExtendLiteral:      extend,
@@ -1897,7 +1897,7 @@ func (p *Parser) parseInputObjectTypeExtension(extend position.Position) {
 	}
 	if p.peekEquals(keyword.LBRACE) {
 		inputObjectTypeDefinition.InputFieldsDefinition = p.parseInputValueDefinitionList(keyword.RBRACE)
-		inputObjectTypeDefinition.HasInputFieldsDefinitions = len(inputObjectTypeDefinition.InputFieldsDefinition.Refs) > 0
+		inputObjectTypeDefinition.HasInputFieldsDefinition = len(inputObjectTypeDefinition.InputFieldsDefinition.Refs) > 0
 	}
 	inputObjectTypeExtension := ast.InputObjectTypeExtension{
 		ExtendLiteral:             extend,

--- a/pkg/astvisitor/simplevisitor.go
+++ b/pkg/astvisitor/simplevisitor.go
@@ -575,7 +575,7 @@ func (w *SimpleWalker) walkEnumTypeDefinition(ref int) {
 		}
 	}
 
-	if w.document.EnumTypeDefinitions[ref].HasEnumValuesDefinitions {
+	if w.document.EnumTypeDefinitions[ref].HasEnumValuesDefinition {
 		for _, i := range w.document.EnumTypeDefinitions[ref].EnumValuesDefinition.Refs {
 			w.walkEnumValueDefinition(i)
 		}
@@ -601,7 +601,7 @@ func (w *SimpleWalker) walkEnumTypeExtension(ref int) {
 		}
 	}
 
-	if w.document.EnumTypeExtensions[ref].HasEnumValuesDefinitions {
+	if w.document.EnumTypeExtensions[ref].HasEnumValuesDefinition {
 		for _, i := range w.document.EnumTypeExtensions[ref].EnumValuesDefinition.Refs {
 			w.walkEnumValueDefinition(i)
 		}
@@ -647,7 +647,7 @@ func (w *SimpleWalker) walkInputObjectTypeDefinition(ref int) {
 		}
 	}
 
-	if w.document.InputObjectTypeDefinitions[ref].HasInputFieldsDefinitions {
+	if w.document.InputObjectTypeDefinitions[ref].HasInputFieldsDefinition {
 		for _, i := range w.document.InputObjectTypeDefinitions[ref].InputFieldsDefinition.Refs {
 			w.walkInputValueDefinition(i)
 		}
@@ -673,7 +673,7 @@ func (w *SimpleWalker) walkInputObjectTypeExtension(ref int) {
 		}
 	}
 
-	if w.document.InputObjectTypeExtensions[ref].HasInputFieldsDefinitions {
+	if w.document.InputObjectTypeExtensions[ref].HasInputFieldsDefinition {
 		for _, i := range w.document.InputObjectTypeExtensions[ref].InputFieldsDefinition.Refs {
 			w.walkInputValueDefinition(i)
 		}

--- a/pkg/astvisitor/visitor.go
+++ b/pkg/astvisitor/visitor.go
@@ -2448,7 +2448,7 @@ func (w *Walker) walkEnumTypeDefinition(ref int) {
 		}
 	}
 
-	if w.document.EnumTypeDefinitions[ref].HasEnumValuesDefinitions {
+	if w.document.EnumTypeDefinitions[ref].HasEnumValuesDefinition {
 		for _, i := range w.document.EnumTypeDefinitions[ref].EnumValuesDefinition.Refs {
 			w.walkEnumValueDefinition(i)
 			if w.stop {
@@ -2513,7 +2513,7 @@ func (w *Walker) walkEnumTypeExtension(ref int) {
 		}
 	}
 
-	if w.document.EnumTypeExtensions[ref].HasEnumValuesDefinitions {
+	if w.document.EnumTypeExtensions[ref].HasEnumValuesDefinition {
 		for _, i := range w.document.EnumTypeExtensions[ref].EnumValuesDefinition.Refs {
 			w.walkEnumValueDefinition(i)
 			if w.stop {
@@ -2634,7 +2634,7 @@ func (w *Walker) walkInputObjectTypeDefinition(ref int) {
 		}
 	}
 
-	if w.document.InputObjectTypeDefinitions[ref].HasInputFieldsDefinitions {
+	if w.document.InputObjectTypeDefinitions[ref].HasInputFieldsDefinition {
 		for _, i := range w.document.InputObjectTypeDefinitions[ref].InputFieldsDefinition.Refs {
 			w.walkInputValueDefinition(i)
 			if w.stop {
@@ -2699,7 +2699,7 @@ func (w *Walker) walkInputObjectTypeExtension(ref int) {
 		}
 	}
 
-	if w.document.InputObjectTypeExtensions[ref].HasInputFieldsDefinitions {
+	if w.document.InputObjectTypeExtensions[ref].HasInputFieldsDefinition {
 		for _, i := range w.document.InputObjectTypeExtensions[ref].InputFieldsDefinition.Refs {
 			w.walkInputValueDefinition(i)
 			if w.stop {


### PR DESCRIPTION
This PR will implement the normalization of the remaining type extensions.
It also contains a [commit](https://github.com/jensneuse/graphql-go-tools/commit/78fb9edba4ddf28f45661788f351e9f897fd99e0) which fixed some naming inconsistencies.