### PR TITLE
fix variable extraction from GraphQL Request

### DIFF
--- a/pkg/execution/datasource_graphql.go
+++ b/pkg/execution/datasource_graphql.go
@@ -328,9 +328,17 @@ func (g *GraphQLDataSource) Resolve(ctx Context, args ResolvedArgs, out io.Write
 		}
 	}
 
+	variablesJson,err := json.Marshal(variables)
+	if err != nil {
+		g.log.Error("GraphQLDataSource.json.Marshal(variables)",
+			zap.Error(err),
+		)
+		return CloseConnectionIfNotStream
+	}
+
 	gqlRequest := GraphqlRequest{
 		OperationName: "o",
-		Variables:     variables,
+		Variables:     variablesJson,
 		Query:         string(queryArg),
 	}
 

--- a/pkg/execution/execution_test.go
+++ b/pkg/execution/execution_test.go
@@ -1199,6 +1199,37 @@ func TestExecutor_ResolveArgs(t *testing.T) {
 	}
 }
 
+func TestExecutor_ResolveArgsString(t *testing.T) {
+	e := NewExecutor()
+	e.context = Context{
+		Context: context.Background(),
+		Variables: map[uint64][]byte{
+			xxhash.Sum64String("id"): []byte("foo123"),
+		},
+	}
+
+	args := []Argument{
+		&StaticVariableArgument{
+			Name:  []byte("url"),
+			Value: []byte("/apis/{{ .arguments.id }}"),
+		},
+		&ContextVariableArgument{
+			Name:         []byte(".arguments.id"),
+			VariableName: []byte("id"),
+		},
+	}
+
+	resolved := e.ResolveArgs(args, nil)
+	if len(resolved) != 1 {
+		t.Fatalf("want 1, got: %d\n", len(resolved))
+		return
+	}
+	want := []byte("/apis/foo123")
+	if !bytes.Equal(resolved.ByKey([]byte("url")), want) {
+		t.Fatalf("want key 'body' with value: '%s'\ndump: %s", string(want), resolved.Dump())
+	}
+}
+
 func TestExecutor_ResolveArgsComplexPayload(t *testing.T) {
 	e := NewExecutor()
 	e.context = Context{

--- a/pkg/execution/handler_test.go
+++ b/pkg/execution/handler_test.go
@@ -2,6 +2,7 @@ package execution
 
 import (
 	"bytes"
+	"github.com/cespare/xxhash"
 	"github.com/jensneuse/diffview"
 	"github.com/sebdah/goldie"
 	"go.uber.org/zap"
@@ -40,5 +41,26 @@ func TestHandler_RenderGraphQLDefinitions(t *testing.T) {
 			panic(err)
 		}
 		diffview.NewGoland().DiffViewBytes("render_graphql_definitions", want, got)
+	}
+}
+
+func TestHandler_VariablesFromRequest(t *testing.T) {
+	handler, err := NewHandler(nil, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := GraphqlRequest{
+		Variables: []byte(`{"foo":"bar"}`),
+	}
+	variables := handler.VariablesFromRequest(request)
+
+	for key,value := range map[string]string{
+		"foo": "bar",
+	}{
+		got := string(variables[xxhash.Sum64String(key)])
+		want := value
+		if got != want{
+			t.Errorf("want {{ %s }}, got: {{ %s }}'",want,got)
+		}
 	}
 }


### PR DESCRIPTION
Variable extraction into the context object led to unwanted quoted strings. This PR fixes the problem.