### PR TITLE
implement validateIfValueSatisfiesInputFieldDefinition for String and Float

### DIFF
--- a/pkg/astvalidation/astvalidation.go
+++ b/pkg/astvalidation/astvalidation.go
@@ -512,6 +512,10 @@ func (v *validArgumentsVisitor) validateIfValueSatisfiesInputFieldDefinition(val
 		satisfied = v.booleanValueSatisfiesInputValueDefinition(inputValueDefinition)
 	case ast.ValueKindInteger:
 		satisfied = v.intValueSatisfiesInputValueDefinition(value, inputValueDefinition)
+	case ast.ValueKindString:
+		satisfied = v.stringValueSatisfiesInputValueDefinition(value, inputValueDefinition)
+	case ast.ValueKindFloat:
+		satisfied = v.floatValueSatisfiesInputValueDefinition(value, inputValueDefinition)
 	case ast.ValueKindObject, ast.ValueKindList:
 		// object- and list values are covered by Values() / valuesVisitor
 		return
@@ -537,6 +541,34 @@ func (v *validArgumentsVisitor) validateIfValueSatisfiesInputFieldDefinition(val
 	}
 
 	v.StopWithExternalErr(operationreport.ErrValueDoesntSatisfyInputValueDefinition(printedValue, printedType))
+}
+
+func (v *validArgumentsVisitor) floatValueSatisfiesInputValueDefinition(value ast.Value, inputValueDefinition int) bool {
+	inputType := v.definition.Types[v.definition.InputValueDefinitionType(inputValueDefinition)]
+	if inputType.TypeKind == ast.TypeKindNonNull {
+		inputType = v.definition.Types[inputType.OfType]
+	}
+	if inputType.TypeKind != ast.TypeKindNamed {
+		return false
+	}
+	if !bytes.Equal(v.definition.Input.ByteSlice(inputType.Name), literal.FLOAT) {
+		return false
+	}
+	return true
+}
+
+func (v *validArgumentsVisitor) stringValueSatisfiesInputValueDefinition(value ast.Value, inputValueDefinition int) bool {
+	inputType := v.definition.Types[v.definition.InputValueDefinitionType(inputValueDefinition)]
+	if inputType.TypeKind == ast.TypeKindNonNull {
+		inputType = v.definition.Types[inputType.OfType]
+	}
+	if inputType.TypeKind != ast.TypeKindNamed {
+		return false
+	}
+	if !bytes.Equal(v.definition.Input.ByteSlice(inputType.Name), literal.STRING) {
+		return false
+	}
+	return true
 }
 
 func (v *validArgumentsVisitor) intValueSatisfiesInputValueDefinition(value ast.Value, inputValueDefinition int) bool {

--- a/pkg/astvalidation/astvalidation_test.go
+++ b/pkg/astvalidation/astvalidation_test.go
@@ -2042,6 +2042,54 @@ func TestExecutionValidation(t *testing.T) {
 							}`,
 					ValidArguments(), Valid)
 			})
+			t.Run("required String", func(t *testing.T) {
+				run(`	query requiredString {
+										args {
+											requiredString(s: "foo")
+										}
+									}`,
+					ValidArguments(), Valid)
+			})
+			t.Run("required String", func(t *testing.T) {
+				run(`	query requiredString {
+										args {
+											requiredString(s: foo)
+										}
+									}`,
+					ValidArguments(), Invalid)
+			})
+			t.Run("required String", func(t *testing.T) {
+				run(`	query requiredString {
+										args {
+											requiredString(s: null)
+										}
+									}`,
+					ValidArguments(), Invalid)
+			})
+			t.Run("required String", func(t *testing.T) {
+				run(`	query requiredFloat {
+										args {
+											requiredFloat(f: 1.1)
+										}
+									}`,
+					ValidArguments(), Valid)
+			})
+			t.Run("required String", func(t *testing.T) {
+				run(`	query requiredFloat {
+										args {
+											requiredFloat(f: "1.1")
+										}
+									}`,
+					ValidArguments(), Invalid)
+			})
+			t.Run("required String", func(t *testing.T) {
+				run(`	query requiredFloat {
+										args {
+											requiredFloat(f: null)
+										}
+									}`,
+					ValidArguments(), Invalid)
+			})
 			t.Run("117 variant", func(t *testing.T) {
 				run(`	
 							query argOnRequiredArg($booleanArg: Boolean!) {
@@ -3938,6 +3986,12 @@ type Query {
   	booleanList(booleanListArg: [Boolean!]): Boolean
 	extra: Extra
 	nested(input: NestedInput): Boolean
+	args: Arguments
+}
+
+type Arguments {
+	requiredString(s: String!): String!
+	requiredFloat(f: Float!): Float!
 }
 
 type ValidArguments {


### PR DESCRIPTION
This PR adds the missing implementation for String and Float types on ValidArguments Rule in package astvalidation. ("validateIfValueSatisfiesInputFieldDefinition")
This PR will close #149 