### PR TITLE
Fixes build for less than 64bit architectures

### DIFF
--- a/pkg/ast/ast_operation_definition.go
+++ b/pkg/ast/ast_operation_definition.go
@@ -66,17 +66,20 @@ const (
 )
 
 func (d *Document) GenerateUnusedVariableDefinitionName(operationDefinition int) []byte {
-	for i := 1;i<math.MaxInt64;i++{
-		out := make([]byte,i)
+	var i, k int64
+
+	for i = 1; i < math.MaxInt64; i++ {
+		out := make([]byte, i)
 		for j := range alphabet {
-			for k := 0;k<i;k++{
+			for k = 0; k < i; k++ {
 				out[k] = alphabet[j]
 			}
-			_,exists := d.VariableDefinitionByNameAndOperation(operationDefinition,out)
+			_, exists := d.VariableDefinitionByNameAndOperation(operationDefinition, out)
 			if !exists {
 				return out
 			}
 		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
On CPU architectures, where data units are less than 64bit wide builds currently fail with an overflow. This is due to implicit type in the for loop iterator `i` in `Document.GenerateUnusedVariableDefinitionName` function, which the compiler guesses as just `int`. This type is architecture dependent, so that on 32bit arch it's an `int32`, while on 64bit one it's an `int64`.

When setting the loop's upper bound at `math.MaxInt64` and trying to compile it with `GOARCH=386` variable `i` would be of `int32` type and thus cause an overflow (which is detected by the compiler). This change makes loop iterator types explicit as `int64`.