### PR TITLE
Feat/allow interface to implement interface

### DIFF
--- a/pkg/ast/ast_interface_type_definition.go
+++ b/pkg/ast/ast_interface_type_definition.go
@@ -1,6 +1,8 @@
 package ast
 
 import (
+	"bytes"
+
 	"github.com/jensneuse/graphql-go-tools/internal/pkg/unsafebytes"
 	"github.com/jensneuse/graphql-go-tools/pkg/lexer/position"
 )
@@ -11,13 +13,14 @@ import (
 // 	name: String
 // }
 type InterfaceTypeDefinition struct {
-	Description         Description        // optional, describes the interface
-	InterfaceLiteral    position.Position  // interface
-	Name                ByteSliceReference // e.g. NamedEntity
-	HasDirectives       bool
-	Directives          DirectiveList // optional, e.g. @foo
-	HasFieldDefinitions bool
-	FieldsDefinition    FieldDefinitionList // optional, e.g. { name: String }
+	Description          Description        // optional, describes the interface
+	InterfaceLiteral     position.Position  // interface
+	Name                 ByteSliceReference // e.g. NamedEntity
+	ImplementsInterfaces TypeList           // e.g implements Bar & Baz
+	HasDirectives        bool
+	Directives           DirectiveList // optional, e.g. @foo
+	HasFieldDefinitions  bool
+	FieldsDefinition     FieldDefinitionList // optional, e.g. { name: String }
 }
 
 func (d *Document) InterfaceTypeDefinitionNameBytes(ref int) ByteSlice {
@@ -33,6 +36,16 @@ func (d *Document) InterfaceTypeDefinitionDescriptionBytes(ref int) ByteSlice {
 		return nil
 	}
 	return d.Input.ByteSlice(d.InterfaceTypeDefinitions[ref].Description.Content)
+}
+
+func (d *Document) InterfaceTypeDefinitionImplementsInterface(definitionRef int, interfaceName ByteSlice) bool {
+	for _, iRef := range d.InterfaceTypeDefinitions[definitionRef].ImplementsInterfaces.Refs {
+		implements := d.ResolveTypeNameBytes(iRef)
+		if bytes.Equal(interfaceName, implements) {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *Document) InterfaceTypeDefinitionDescriptionString(ref int) string {

--- a/pkg/astparser/parser.go
+++ b/pkg/astparser/parser.go
@@ -1841,6 +1841,9 @@ func (p *Parser) parseInterfaceTypeExtension(extend position.Position) {
 	var interfaceTypeDefinition ast.InterfaceTypeDefinition
 	interfaceTypeDefinition.InterfaceLiteral = p.mustReadIdentKey(identkeyword.INTERFACE).TextPosition
 	interfaceTypeDefinition.Name = p.mustRead(keyword.IDENT).Literal
+	if p.peekEqualsIdentKey(identkeyword.IMPLEMENTS) {
+		interfaceTypeDefinition.ImplementsInterfaces = p.parseImplementsInterfaces()
+	}
 	if p.peekEquals(keyword.AT) {
 		interfaceTypeDefinition.Directives = p.parseDirectiveList()
 		interfaceTypeDefinition.HasDirectives = len(interfaceTypeDefinition.Directives.Refs) > 0

--- a/pkg/astparser/parser.go
+++ b/pkg/astparser/parser.go
@@ -1204,6 +1204,9 @@ func (p *Parser) parseInterfaceTypeDefinition(description *ast.Description) {
 		interfaceTypeDefinition.Directives = p.parseDirectiveList()
 		interfaceTypeDefinition.HasDirectives = len(interfaceTypeDefinition.Directives.Refs) > 0
 	}
+	if p.peekEqualsIdentKey(identkeyword.IMPLEMENTS) {
+		interfaceTypeDefinition.ImplementsInterfaces = p.parseImplementsInterfaces()
+	}
 	if p.peekEquals(keyword.LBRACE) {
 		interfaceTypeDefinition.FieldsDefinition = p.parseFieldDefinitionList()
 		interfaceTypeDefinition.HasFieldDefinitions = len(interfaceTypeDefinition.FieldsDefinition.Refs) > 0

--- a/pkg/astparser/parser_test.go
+++ b/pkg/astparser/parser_test.go
@@ -858,6 +858,32 @@ func TestParser_Parse(t *testing.T) {
 					}
 				})
 		})
+		t.Run("with interface implementation", func(t *testing.T) {
+			run(`interface NamedEntity implements Foo & Bar {
+ 								name: String
+							}`, parse, false,
+				func(doc *ast.Document, extra interface{}) {
+					namedEntity := doc.InterfaceTypeDefinitions[0]
+					if doc.Input.ByteSliceString(namedEntity.Name) != "NamedEntity" {
+						panic("want NamedEntity")
+					}
+					implementsFoo := doc.Types[namedEntity.ImplementsInterfaces.Refs[0]]
+					if implementsFoo.TypeKind != ast.TypeKindNamed {
+						panic("want TypeKindNamed")
+					}
+					if doc.Input.ByteSliceString(implementsFoo.Name) != "Foo" {
+						panic("want Foo")
+					}
+
+					implementsBar := doc.Types[namedEntity.ImplementsInterfaces.Refs[1]]
+					if implementsBar.TypeKind != ast.TypeKindNamed {
+						panic("want TypeKindNamed")
+					}
+					if doc.Input.ByteSliceString(implementsBar.Name) != "Bar" {
+						panic("want Bar")
+					}
+				})
+		})
 	})
 	t.Run("union type definition", func(t *testing.T) {
 		t.Run("simple", func(t *testing.T) {

--- a/pkg/astparser/parser_test.go
+++ b/pkg/astparser/parser_test.go
@@ -401,6 +401,39 @@ func TestParser_Parse(t *testing.T) {
 					}
 				})
 		})
+		t.Run("with interface implementation", func(t *testing.T) {
+			run(`extend interface NamedEntity implements Foo & Bar {
+ 								name: String
+							}`, parse, false,
+				func(doc *ast.Document, extra interface{}) {
+					namedEntity := doc.InterfaceTypeExtensions[0]
+					if doc.Input.ByteSliceString(namedEntity.Name) != "NamedEntity" {
+						panic("want NamedEntity")
+					}
+
+					implementsFoo := doc.Types[namedEntity.ImplementsInterfaces.Refs[0]]
+					if implementsFoo.TypeKind != ast.TypeKindNamed {
+						panic("want TypeKindNamed")
+					}
+					if doc.Input.ByteSliceString(implementsFoo.Name) != "Foo" {
+						panic("want Foo")
+					}
+
+					implementsBar := doc.Types[namedEntity.ImplementsInterfaces.Refs[1]]
+					if implementsBar.TypeKind != ast.TypeKindNamed {
+						panic("want TypeKindNamed")
+					}
+					if doc.Input.ByteSliceString(implementsBar.Name) != "Bar" {
+						panic("want Bar")
+					}
+
+					// fields
+					name := doc.FieldDefinitions[namedEntity.FieldsDefinition.Refs[0]]
+					if doc.Input.ByteSliceString(name.Name) != "name" {
+						panic("want name")
+					}
+				})
+		})
 	})
 	t.Run("scalar type extension", func(t *testing.T) {
 		t.Run("simple", func(t *testing.T) {

--- a/pkg/astparser/parser_test.go
+++ b/pkg/astparser/parser_test.go
@@ -379,7 +379,7 @@ func TestParser_Parse(t *testing.T) {
 	})
 	t.Run("interface type extension", func(t *testing.T) {
 		t.Run("simple", func(t *testing.T) {
-			run(`extend interface NamedEntity @foo {
+			run(`extend interface NamedEntity {
  								name: String
 							}`, parse, false,
 				func(doc *ast.Document, extra interface{}) {


### PR DESCRIPTION
This PR allows for parsing the following structures
```graphql
interface NamedNode implements Node {
  name: String
}
```
and
```graphql
extend interface NamedEntity implements Foo & Bar {
  name: String
}
```
as mentioned in [this issue](https://github.com/graphql/graphql-spec/issues/295)