### PR TITLE
Fix/context is missing in the arguments of subscription.NewExecutorV2Pool in the federation example

### DIFF
--- a/examples/federation/gateway/http/ws.go
+++ b/examples/federation/gateway/http/ws.go
@@ -148,7 +148,7 @@ func (g *GraphQLHTTPRequestHandler) handleWebsocket(conn net.Conn) {
 	done := make(chan bool)
 	errChan := make(chan error)
 
-	executorPool := subscription.NewExecutorV2Pool(g.engine)
+	executorPool := subscription.NewExecutorV2Pool(g.engine, context.Background())
 	go HandleWebsocket(done, errChan, conn, executorPool, g.log)
 	select {
 	case err := <-errChan:


### PR DESCRIPTION
fix(example): add context.Backgrount() to the arguments of subscription.NewExecutorV2Pool

It's a regression bug introduced int 83a5ad29 of #148.