### PR TITLE
Don't include all external fields in a type's child fields.

### DIFF
--- a/pkg/engine/plan/local_type_field_extractor_test.go
+++ b/pkg/engine/plan/local_type_field_extractor_test.go
@@ -548,6 +548,30 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 				{TypeName: "User", FieldNames: []string{"id", "reviews"}},
 			})
 	})
+	t.Run("extended Entity with required fields", func(t *testing.T) {
+		run(t, `
+			extend type User @key(fields: "id") {
+				id: ID! @external
+				username: String! @external
+				lastname: String! @external
+
+				reviews: [Review!]
+				fullname: String @requires(fields: "{ lastname }")
+			}
+
+			type Review {
+				comment: String!
+				author: User! @provide(fields: "username")
+			}
+		`,
+			[]TypeField{
+				{TypeName: "User", FieldNames: []string{"fullname", "reviews"}},
+			},
+			[]TypeField{
+				{TypeName: "Review", FieldNames: []string{"author", "comment"}},
+				{TypeName: "User", FieldNames: []string{"fullname", "id", "reviews", "username"}},
+			})
+	})
 	t.Run("local type extension", func(t *testing.T) {
 		run(t, `
            extend type Query {

--- a/pkg/engine/plan/required_field_extractor.go
+++ b/pkg/engine/plan/required_field_extractor.go
@@ -6,9 +6,7 @@ import (
 	"github.com/jensneuse/graphql-go-tools/pkg/ast"
 )
 
-var (
-	fieldsArgumentNameBytes = []byte("fields")
-)
+var fieldsArgumentNameBytes = []byte("fields")
 
 // RequiredFieldExtractor extracts all required fields from an ast.Document
 // containing a parsed federation subgraph SDL
@@ -53,7 +51,7 @@ func (f *RequiredFieldExtractor) addFieldsForObjectExtensionDefinitions(fieldReq
 			requiredFields := make([]string, len(primaryKeys))
 			copy(requiredFields, primaryKeys)
 
-			requiredFieldsByRequiresDirective := f.requiredFieldsByRequiresDirective(fieldDefinitionRef)
+			requiredFieldsByRequiresDirective := requiredFieldsByRequiresDirective(f.document, fieldDefinitionRef)
 			requiredFields = append(requiredFields, requiredFieldsByRequiresDirective...)
 
 			*fieldRequires = append(*fieldRequires, FieldConfiguration{
@@ -97,13 +95,13 @@ func (f *RequiredFieldExtractor) addFieldsForObjectDefinitions(fieldRequires *Fi
 	}
 }
 
-func (f *RequiredFieldExtractor) requiredFieldsByRequiresDirective(fieldDefinitionRef int) []string {
-	for _, directiveRef := range f.document.FieldDefinitions[fieldDefinitionRef].Directives.Refs {
-		if directiveName := f.document.DirectiveNameString(directiveRef); directiveName != federationRequireDirectiveName {
+func requiredFieldsByRequiresDirective(document *ast.Document, fieldDefinitionRef int) []string {
+	for _, directiveRef := range document.FieldDefinitions[fieldDefinitionRef].Directives.Refs {
+		if directiveName := document.DirectiveNameString(directiveRef); directiveName != federationRequireDirectiveName {
 			continue
 		}
 
-		value, exists := f.document.DirectiveArgumentValueByName(directiveRef, fieldsArgumentNameBytes)
+		value, exists := document.DirectiveArgumentValueByName(directiveRef, fieldsArgumentNameBytes)
 		if !exists {
 			continue
 		}
@@ -111,7 +109,7 @@ func (f *RequiredFieldExtractor) requiredFieldsByRequiresDirective(fieldDefiniti
 			continue
 		}
 
-		fieldsStr := f.document.StringValueContentString(value.Ref)
+		fieldsStr := document.StringValueContentString(value.Ref)
 
 		return strings.Split(fieldsStr, " ")
 	}


### PR DESCRIPTION
The local type field extractor is responsible for saying what fields
of what types can be resolved by a given datasource (upstream server).
This includes all the fields owned by the datasource, but it also
includes `@key` fields for federated types, since if you are extending
a type you know the value of its key field by definition, and
`@provides` fields.

The logic in local-type-field extractor was using `@external` as a
synonym for "is in a @key or @provides field".  Unfortunately, there's
a third reason a field might be declared `@external`: it's `@require`d
somewhere.  And such fields should definitely *not* be considered to
be owned by datasource.  (In fact, here "external" is saying exactly
the opposite of that!)

This PR extends the logic of the local-type-field extractor to ignore
external fields that are also marked `@required` in the same
type-extension.  This doubles down on the "negative" approach
(assuming everything external is actually provided except for explicit
exceptions) rather than the "positive" approach of actually
enumerating the instances where the schema reports a field is provided
(namely `@provides` and `@key` directives).  This is due to the
difficulty of parsing non-trivial key/provides fields like `@key:
"child { address { city } }"`.  It should work well unless there's a
fourth reason to mark something `@external` that we're missing!

(Of course, someone could add an `@external` field just for the heck
of it and things might break then.  So a "positive" approach would
still be better one day.)

One could imagine legitimate, but baroque, corner cases where this
fails, for instance something like:
```
extend type User {
    name: String @external
    fullName: String @requires("name")
}

extend type Review {
    reviewer: User @provides("name")
}
```
where `User.name` is locally providable in some contexts but not
others.  In that case we'll basically ignore the `@provides` here,
which is sub-optimal but not, technically, incorrect.