### PR TITLE
WIP: Fix OnTypeName resolve panic

### DIFF
--- a/pkg/engine/resolve/resolve.go
+++ b/pkg/engine/resolve/resolve.go
@@ -81,8 +81,10 @@ type Node interface {
 	NodeKind() NodeKind
 }
 
-type NodeKind int
-type FetchKind int
+type (
+	NodeKind  int
+	FetchKind int
+)
 
 const (
 	NodeKindObject NodeKind = iota + 1
@@ -231,6 +233,7 @@ func (c *Context) addResponseArrayElements(elements []string) {
 func (c *Context) removeResponseLastElements(elements []string) {
 	c.responseElements = c.responseElements[:len(c.responseElements)-len(elements)]
 }
+
 func (c *Context) removeResponseArrayLastElements(elements []string) {
 	c.responseElements = c.responseElements[:len(c.responseElements)-(len(elements)+1)]
 }
@@ -439,9 +442,7 @@ func extractResponse(responseData []byte, bufPair *BufPair, cfg ProcessResponseC
 		switch i {
 		case rootErrorsPathIndex:
 			_, _ = jsonparser.ArrayEach(bytes, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
-				var (
-					message, locations, path, extensions []byte
-				)
+				var message, locations, path, extensions []byte
 				jsonparser.EachKey(value, func(i int, bytes []byte, valueType jsonparser.ValueType, err error) {
 					switch i {
 					case errorsMessagePathIndex:
@@ -506,7 +507,6 @@ func (r *Resolver) ResolveGraphQLResponse(ctx *Context, response *GraphQLRespons
 }
 
 func (r *Resolver) ResolveGraphQLSubscription(ctx *Context, subscription *GraphQLSubscription, writer FlushWriter) (err error) {
-
 	buf := r.getBufPair()
 	err = subscription.Trigger.InputTemplate.Render(ctx, nil, buf.Data)
 	if err != nil {
@@ -554,7 +554,6 @@ func (r *Resolver) ResolveGraphQLSubscription(ctx *Context, subscription *GraphQ
 }
 
 func (r *Resolver) ResolveGraphQLStreamingResponse(ctx *Context, response *GraphQLStreamingResponse, data []byte, writer FlushWriter) (err error) {
-
 	if err := r.validateContext(ctx); err != nil {
 		return err
 	}
@@ -627,7 +626,6 @@ Loop:
 }
 
 func (r *Resolver) ResolveGraphQLResponsePatch(ctx *Context, patch *GraphQLResponsePatch, data, path, extraPath []byte, writer io.Writer) (err error) {
-
 	buf := r.getBufPair()
 	defer r.freeBufPair(buf)
 
@@ -748,7 +746,6 @@ func (r *Resolver) resolveArray(ctx *Context, array *Array, data []byte, arrayBu
 }
 
 func (r *Resolver) resolveArraySynchronous(ctx *Context, array *Array, arrayItems *[][]byte, arrayBuf *BufPair) (err error) {
-
 	itemBuf := r.getBufPair()
 	defer r.freeBufPair(itemBuf)
 
@@ -795,7 +792,6 @@ func (r *Resolver) resolveArraySynchronous(ctx *Context, array *Array, arrayItem
 }
 
 func (r *Resolver) resolveArrayAsynchronous(ctx *Context, array *Array, arrayItems *[][]byte, arrayBuf *BufPair) (err error) {
-
 	arrayBuf.Data.WriteBytes(lBrack)
 
 	bufSlice := r.getBufPairSlice()
@@ -1078,6 +1074,8 @@ func (r *Resolver) resolveObject(ctx *Context, object *Object, data []byte, obje
 			typeName, _, _, _ := jsonparser.Get(fieldData, "__typename")
 			if !bytes.Equal(typeName, object.Fields[i].OnTypeName) {
 				typeNameSkip = true
+				// Restore the response elements that may have been reset above.
+				ctx.responseElements = responseElements
 				continue
 			}
 		}
@@ -1155,7 +1153,6 @@ func (r *Resolver) freeResultSet(set *resultSet) {
 }
 
 func (r *Resolver) resolveFetch(ctx *Context, fetch Fetch, data []byte, set *resultSet) (err error) {
-
 	switch f := fetch.(type) {
 	case *SingleFetch:
 		preparedInput := r.getBufPair()

--- a/pkg/engine/resolve/resolve.go
+++ b/pkg/engine/resolve/resolve.go
@@ -1076,6 +1076,7 @@ func (r *Resolver) resolveObject(ctx *Context, object *Object, data []byte, obje
 				typeNameSkip = true
 				// Restore the response elements that may have been reset above.
 				ctx.responseElements = responseElements
+				ctx.lastFetchID = lastFetchID
 				continue
 			}
 		}


### PR DESCRIPTION
There's a panic that occurs when resolving an object field and 1) the
object has an associated fetch, and 2) the field being resolved is
skipped because OnTypeName is set. In this case the context
`responseElements` are reset, but they aren't restored when skipping the
field. This results in a panic later when attemping to remove the
existing path elements from the context.

This PR is a work-in-progress because I still need to construct a test
case to demonstrate the issue.