### PR TITLE
treat a union intersecting an interface symmetrically from interface | union

### DIFF
--- a/pkg/ast/ast_node.go
+++ b/pkg/ast/ast_node.go
@@ -499,7 +499,7 @@ func (d *Document) NodeFragmentIsAllowedOnUnionTypeDefinition(fragmentNode, unio
 	case NodeKindObjectTypeDefinition:
 		return d.NodeIsUnionMember(fragmentNode, unionTypeNode)
 	case NodeKindInterfaceTypeDefinition:
-		return false
+		return d.UnionNodeIntersectsInterfaceNode(unionTypeNode, fragmentNode)
 	case NodeKindUnionTypeDefinition:
 		return bytes.Equal(d.UnionTypeDefinitionNameBytes(fragmentNode.Ref), d.UnionTypeDefinitionNameBytes(unionTypeNode.Ref))
 	}

--- a/pkg/astnormalization/fragment_spread_inlining.go
+++ b/pkg/astnormalization/fragment_spread_inlining.go
@@ -43,7 +43,6 @@ func (f *fragmentSpreadInlineVisitor) LeaveDocument(operation, definition *ast.D
 }
 
 func (f *fragmentSpreadInlineVisitor) EnterFragmentSpread(ref int) {
-
 	parentTypeName := f.definition.NodeNameBytes(f.EnclosingTypeDefinition)
 
 	fragmentDefinitionRef, exists := f.operation.FragmentDefinitionRef(f.operation.FragmentSpreadNameBytes(ref))
@@ -66,6 +65,7 @@ func (f *fragmentSpreadInlineVisitor) EnterFragmentSpread(ref int) {
 	var fragmentTypeImplementsEnclosingType bool
 	var fragmentTypeIsMemberOfEnclosingUnionType bool
 	var fragmentUnionIntersectsEnclosingInterface bool
+	var fragmentInterfaceIntersectsEnclosingUnion bool
 
 	if fragmentNode.Kind == ast.NodeKindInterfaceTypeDefinition && f.EnclosingTypeDefinition.Kind == ast.NodeKindObjectTypeDefinition {
 		enclosingTypeImplementsFragmentType = f.definition.NodeImplementsInterface(f.EnclosingTypeDefinition, fragmentNode)
@@ -81,6 +81,10 @@ func (f *fragmentSpreadInlineVisitor) EnterFragmentSpread(ref int) {
 
 	if f.EnclosingTypeDefinition.Kind == ast.NodeKindInterfaceTypeDefinition && fragmentNode.Kind == ast.NodeKindUnionTypeDefinition {
 		fragmentUnionIntersectsEnclosingInterface = f.definition.UnionNodeIntersectsInterfaceNode(fragmentNode, f.EnclosingTypeDefinition)
+	}
+
+	if f.EnclosingTypeDefinition.Kind == ast.NodeKindUnionTypeDefinition && fragmentNode.Kind == ast.NodeKindInterfaceTypeDefinition {
+		fragmentInterfaceIntersectsEnclosingUnion = f.definition.UnionNodeIntersectsInterfaceNode(f.EnclosingTypeDefinition, fragmentNode)
 	}
 
 	if f.EnclosingTypeDefinition.Kind == ast.NodeKindUnionTypeDefinition {
@@ -105,7 +109,7 @@ func (f *fragmentSpreadInlineVisitor) EnterFragmentSpread(ref int) {
 	switch {
 	case fragmentTypeEqualsParentType || enclosingTypeImplementsFragmentType:
 		f.transformer.ReplaceFragmentSpread(precedence, selectionSet, ref, replaceWith)
-	case fragmentTypeImplementsEnclosingType || fragmentTypeIsMemberOfEnclosingUnionType || enclosingTypeIsMemberOfFragmentUnion || fragmentUnionIntersectsEnclosingInterface:
+	case fragmentTypeImplementsEnclosingType || fragmentTypeIsMemberOfEnclosingUnionType || enclosingTypeIsMemberOfFragmentUnion || fragmentUnionIntersectsEnclosingInterface || fragmentInterfaceIntersectsEnclosingUnion:
 		f.transformer.ReplaceFragmentSpreadWithInlineFragment(precedence, selectionSet, ref, replaceWith, typeCondition)
 	}
 }

--- a/pkg/astnormalization/fragment_spread_inlining_test.go
+++ b/pkg/astnormalization/fragment_spread_inlining_test.go
@@ -372,6 +372,45 @@ func TestInlineFragments(t *testing.T) {
 					}
 				}`)
 	})
+	t.Run("inline fragment inside interface inside union inside type", func(t *testing.T) {
+		run(fragmentSpreadInline, testDefinition, `
+				{
+					dog {
+						...interfaceWithUnion
+					}
+				}
+				fragment interfaceWithUnion on DogOrHuman {
+					...petFragment
+				}
+				fragment petFragment on Pet {
+					... on Dog {
+						barkVolume
+					}
+				}`, `
+				{
+					dog {
+						... on DogOrHuman {
+							... on Pet {
+								... on Dog {
+									barkVolume
+								}
+							}
+						}
+					}
+				}
+				fragment interfaceWithUnion on DogOrHuman {
+					... on Pet {
+						... on Dog {
+							barkVolume
+						}
+					}
+				}
+				fragment petFragment on Pet {
+					... on Dog {
+						barkVolume
+					}
+				}`)
+	})
 	t.Run("non intersecting interfaces shouldn't merge", func(t *testing.T) {
 		run(fragmentSpreadInline, testDefinition, `
 				{

--- a/pkg/astvalidation/operation_validation_test.go
+++ b/pkg/astvalidation/operation_validation_test.go
@@ -2704,7 +2704,7 @@ func TestExecutionValidation(t *testing.T) {
 									}`,
 							Fragments(), Invalid)
 					})
-					t.Run("142", func(t *testing.T) {
+					t.Run("142 variant", func(t *testing.T) {
 						run(` fragment humanOrAlienFragment on HumanOrAlien {
 										... on Cat {
 											meowVolume
@@ -2725,6 +2725,23 @@ func TestExecutionValidation(t *testing.T) {
 										...dogOrHumanFragment
 									}
 									fragment dogOrHumanFragment on DogOrHuman {
+										... on Dog {
+											barkVolume
+										}
+									}`,
+							Fragments(), Valid)
+					})
+					t.Run("143 variant", func(t *testing.T) {
+						run(`
+									{
+										dog {
+											...interfaceWithUnion
+										}
+									}
+									fragment interfaceWithUnion on DogOrHuman {
+										...petFragment
+									}
+									fragment petFragment on Pet {
 										... on Dog {
 											barkVolume
 										}


### PR DESCRIPTION
```
When expanding a named fragment, one of the cases to consider is that
the named fragment has union type, but the enclosing type is an
interface type.  (e.g. `user { ...data } fragment data on SomeUnion {...}`,
where `user` has an interface type.  fragment_spread_inlining.go already
treats this case correctly.

However, there's a symmetrical case where the enclosing type is a
union, and the naamed fragment has an interface type.  According to
the spec, this should be treated identically, but
fragment_spread_inlining.go was not considering this case.  With this
PR it is.

Fixing this turned up another problem in ast_node.go:
NodeFragmentIsAllowedOnInterfaceTypeDefinition properly allowed the
fragment on union types when appropriate, but in the symmetrical case,
NodeFragmentIsAllowedOnUnionTypeDefinition _never_ allowed the
fragment on interface types.  Now it uses the same condition as the
other case, allowing it when there's a non-zero intersection of the
two types.
```
from @csilvers 