### PR TITLE
Decoupled GraphQL DataSource Planner from HTTP

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_http_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_http_datasource/graphql_datasource.go
@@ -1,0 +1,190 @@
+package graphql_http_datasource
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/buger/jsonparser"
+	"github.com/jensneuse/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
+	"github.com/jensneuse/graphql-go-tools/pkg/engine/datasource/httpclient"
+	"github.com/jensneuse/graphql-go-tools/pkg/engine/plan"
+	"github.com/jensneuse/graphql-go-tools/pkg/engine/resolve"
+	"github.com/jensneuse/graphql-go-tools/pkg/lexer/literal"
+)
+
+type SubscriptionConfiguration struct {
+	URL string
+}
+
+type FetchConfiguration struct {
+	URL    string
+	Method string
+	Header http.Header
+}
+
+type HTTPConfiguration struct {
+	Fetch        FetchConfiguration
+	Subscription SubscriptionConfiguration
+}
+
+func (c *HTTPConfiguration) ApplyDefaults() {
+	if c.Fetch.Method == "" {
+		c.Fetch.Method = "POST"
+	}
+}
+
+type HTTPSource struct {
+	config             HTTPConfiguration
+	fetchClient        *http.Client
+	subscriptionClient graphql_datasource.GraphQLSubscriptionClient
+}
+
+func (p *HTTPSource) ApplyDefaults() {
+	p.config.ApplyDefaults()
+}
+
+func (p *HTTPSource) ConfigureFetch(params graphql_datasource.ConfigureFetchParams) graphql_datasource.ConfigureFetchResponse {
+	var input []byte
+	input = httpclient.SetInputBodyWithPath(input, params.UpstreamVariables, "variables")
+	input = httpclient.SetInputBodyWithPath(input, params.Operation, "query")
+
+	header, err := json.Marshal(p.config.Fetch.Header)
+	if err == nil && len(header) != 0 && !bytes.Equal(header, literal.NULL) {
+		input = httpclient.SetInputHeader(input, header)
+	}
+
+	input = httpclient.SetInputURL(input, []byte(p.config.Fetch.URL))
+	input = httpclient.SetInputMethod(input, []byte(p.config.Fetch.Method))
+
+	return graphql_datasource.ConfigureFetchResponse{
+		Input: string(input),
+		DataSource: &FetchSource{
+			httpClient: p.fetchClient,
+		},
+	}
+}
+
+type FetchSource struct {
+	httpClient *http.Client
+}
+
+func (s *FetchSource) compactAndUnNullVariables(input []byte) []byte {
+	variables, _, _, err := jsonparser.Get(input, "body", "variables")
+	if err != nil {
+		return input
+	}
+	if bytes.Equal(variables, []byte("null")) || bytes.Equal(variables, []byte("{}")) {
+		return input
+	}
+	if bytes.ContainsAny(variables, " \t\n\r") {
+		buf := bytes.NewBuffer(make([]byte, 0, len(variables)))
+		_ = json.Compact(buf, variables)
+		variables = buf.Bytes()
+	}
+	cp := make([]byte, len(variables))
+	copy(cp, variables)
+	variables = cp
+	var changed bool
+	for {
+		variables, changed = s.unNullVariables(variables)
+		if !changed {
+			break
+		}
+	}
+	input, _ = jsonparser.Set(input, variables, "body", "variables")
+	return input
+}
+
+func (s *FetchSource) unNullVariables(input []byte) ([]byte, bool) {
+	if i := bytes.Index(input, []byte(":{}")); i != -1 {
+		end := i + 3
+		hasTrainlingComma := false
+		if input[end] == ',' {
+			end++
+			hasTrainlingComma = true
+		}
+		startQuote := bytes.LastIndex(input[:i-2], []byte("\""))
+		if !hasTrainlingComma && input[startQuote-1] == ',' {
+			startQuote--
+		}
+		return append(input[:startQuote], input[end:]...), true
+	}
+	if i := bytes.Index(input, []byte("null")); i != -1 {
+		end := i + 4
+		hasTrailingComma := false
+		if input[end] == ',' {
+			end++
+			hasTrailingComma = true
+		}
+		startQuote := bytes.LastIndex(input[:i-2], []byte("\""))
+		if !hasTrailingComma && input[startQuote-1] == ',' {
+			startQuote--
+		}
+		return append(input[:startQuote], input[end:]...), true
+	}
+	return input, false
+}
+
+func (s *FetchSource) Load(ctx context.Context, input []byte, writer io.Writer) (err error) {
+	input = s.compactAndUnNullVariables(input)
+	return httpclient.Do(s.httpClient, ctx, input, writer)
+}
+
+func (p *HTTPSource) ConfigureSubscription(params graphql_datasource.ConfigureSubscriptionParams) graphql_datasource.ConfigureSubscriptionResponse {
+	input := httpclient.SetInputBodyWithPath(nil, params.UpstreamVariables, "variables")
+	input = httpclient.SetInputBodyWithPath(input, params.Operation, "query")
+	input = httpclient.SetInputURL(input, []byte(p.config.Subscription.URL))
+
+	header, err := json.Marshal(p.config.Fetch.Header)
+	if err == nil && len(header) != 0 && !bytes.Equal(header, literal.NULL) {
+		input = httpclient.SetInputHeader(input, header)
+	}
+
+	return graphql_datasource.ConfigureSubscriptionResponse{
+		Input: string(input),
+		DataSource: &SubscriptionSource{
+			client: p.subscriptionClient,
+		},
+	}
+}
+
+type SubscriptionSource struct {
+	client graphql_datasource.GraphQLSubscriptionClient
+}
+
+func (s *SubscriptionSource) Start(ctx context.Context, input []byte, next chan<- []byte) error {
+	var options graphql_datasource.GraphQLSubscriptionOptions
+	err := json.Unmarshal(input, &options)
+	if err != nil {
+		return err
+	}
+	if options.Body.Query == "" {
+		return resolve.ErrUnableToResolve
+	}
+	return s.client.Subscribe(ctx, options, next)
+}
+
+type Factory struct {
+	BatchFactory resolve.DataSourceBatchFactory
+	HTTPClient   *http.Client
+	wsClient     *WebSocketGraphQLSubscriptionClient
+}
+
+func (f *Factory) Planner(ctx context.Context) plan.DataSourcePlanner {
+	if f.wsClient == nil {
+		f.wsClient = NewWebSocketGraphQLSubscriptionClient(f.HTTPClient, ctx)
+	}
+
+	source := &HTTPSource{
+		fetchClient:        f.HTTPClient,
+		subscriptionClient: f.wsClient,
+	}
+
+	return graphql_datasource.NewPlanner(
+		f.BatchFactory,
+		source,
+	)
+}

--- a/pkg/engine/datasource/graphql_datasource/graphql_http_datasource/graphql_subscription_client.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_http_datasource/graphql_subscription_client.go
@@ -1,4 +1,4 @@
-package graphql_datasource
+package graphql_http_datasource
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/cespare/xxhash/v2"
 	"github.com/jensneuse/abstractlogger"
+	"github.com/jensneuse/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
 	"nhooyr.io/websocket"
 )
 
@@ -85,7 +86,11 @@ func NewWebSocketGraphQLSubscriptionClient(httpClient *http.Client, ctx context.
 // Each WebSocket (WS) to an origin is uniquely identified by the Hash(URL,Headers,Body)
 // If an existing WS with the same ID (Hash) exists, it is being re-used
 // If no connection exists, the client initiates a new one and sends the "init" and "connection ack" messages
-func (c *WebSocketGraphQLSubscriptionClient) Subscribe(ctx context.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error {
+func (c *WebSocketGraphQLSubscriptionClient) Subscribe(
+	ctx context.Context,
+	options graphql_datasource.GraphQLSubscriptionOptions,
+	next chan<- []byte,
+) error {
 
 	handlerID, err := c.generateHandlerIDHash(options)
 	if err != nil {
@@ -161,7 +166,9 @@ func (c *WebSocketGraphQLSubscriptionClient) Subscribe(ctx context.Context, opti
 }
 
 // generateHandlerIDHash generates a Hash based on: URL and Headers to uniquely identify Upgrade Requests
-func (c *WebSocketGraphQLSubscriptionClient) generateHandlerIDHash(options GraphQLSubscriptionOptions) (uint64, error) {
+func (c *WebSocketGraphQLSubscriptionClient) generateHandlerIDHash(
+	options graphql_datasource.GraphQLSubscriptionOptions,
+) (uint64, error) {
 	var (
 		err error
 	)
@@ -208,7 +215,7 @@ type connectionHandler struct {
 
 type subscription struct {
 	ctx     context.Context
-	options GraphQLSubscriptionOptions
+	options graphql_datasource.GraphQLSubscriptionOptions
 	next    chan<- []byte
 }
 

--- a/pkg/engine/datasource/graphql_datasource/graphql_http_datasource/graphql_subscription_client_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_http_datasource/graphql_subscription_client_test.go
@@ -1,4 +1,4 @@
-package graphql_datasource
+package graphql_http_datasource
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 
 	"github.com/buger/jsonparser"
 	ll "github.com/jensneuse/abstractlogger"
+	"github.com/jensneuse/graphql-go-tools/pkg/engine/datasource/graphql_datasource"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
@@ -68,9 +69,9 @@ func TestWebsocketSubscriptionClient(t *testing.T) {
 		WithLogger(logger()),
 	)
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(ctx, graphql_datasource.GraphQLSubscriptionOptions{
 		URL: strings.Replace(server.URL, "http", "ws", -1),
-		Body: GraphQLBody{
+		Body: graphql_datasource.GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
 	}, next)
@@ -107,9 +108,9 @@ func TestWebsocketSubscriptionClientImmediateClientCancel(t *testing.T) {
 		WithLogger(logger()),
 	)
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(ctx, graphql_datasource.GraphQLSubscriptionOptions{
 		URL: strings.Replace(server.URL, "http", "ws", -1),
-		Body: GraphQLBody{
+		Body: graphql_datasource.GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
 	}, next)
@@ -161,9 +162,9 @@ func TestWebsocketSubscriptionClientWithServerDisconnect(t *testing.T) {
 		WithLogger(logger()),
 	)
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(ctx, graphql_datasource.GraphQLSubscriptionOptions{
 		URL: strings.Replace(server.URL, "http", "ws", -1),
-		Body: GraphQLBody{
+		Body: graphql_datasource.GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
 	}, next)
@@ -218,9 +219,9 @@ func TestWebsocketSubscriptionClientErrorArray(t *testing.T) {
 		WithLogger(logger()),
 	)
 	next := make(chan []byte)
-	err := client.Subscribe(clientCtx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(clientCtx, graphql_datasource.GraphQLSubscriptionOptions{
 		URL: strings.Replace(server.URL, "http", "ws", -1),
-		Body: GraphQLBody{
+		Body: graphql_datasource.GraphQLBody{
 			Query: `subscription {messageAdded(roomNam: "room"){text}}`,
 		},
 	}, next)
@@ -270,9 +271,9 @@ func TestWebsocketSubscriptionClientErrorObject(t *testing.T) {
 		WithLogger(logger()),
 	)
 	next := make(chan []byte)
-	err := client.Subscribe(clientCtx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(clientCtx, graphql_datasource.GraphQLSubscriptionOptions{
 		URL: strings.Replace(server.URL, "http", "ws", -1),
-		Body: GraphQLBody{
+		Body: graphql_datasource.GraphQLBody{
 			Query: `subscription {messageAdded(roomNam: "room"){text}}`,
 		},
 	}, next)
@@ -383,9 +384,9 @@ func TestWebsocketSubscriptionClientDeDuplication(t *testing.T) {
 
 	next := make(chan []byte)
 	ctx, clientCancel := context.WithCancel(context.Background())
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(ctx, graphql_datasource.GraphQLSubscriptionOptions{
 		URL: strings.Replace(server.URL, "http", "ws", -1),
-		Body: GraphQLBody{
+		Body: graphql_datasource.GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
 	}, next)
@@ -398,9 +399,9 @@ func TestWebsocketSubscriptionClientDeDuplication(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 
-		err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		err := client.Subscribe(ctx, graphql_datasource.GraphQLSubscriptionOptions{
 			URL: strings.Replace(server.URL, "http", "ws", -1),
-			Body: GraphQLBody{
+			Body: graphql_datasource.GraphQLBody{
 				Query: `subscription {messageAdded(roomName: "room"){text}}`,
 			},
 		}, next)


### PR DESCRIPTION
It now uses a GraphqlDatasource interface to configure the
fetch and subscription. This will enable us to call into a local
GraphQL executable schema as well as a remote HTTP GraphQL
server.

I haven't solved how to handle configuration yet. Since config is different for different types of GraphQL data sources I need to figure out how to support this.