### PR TITLE
fix broken object variable rendering when handling strings

### DIFF
--- a/pkg/engine/datasource/introspection_datasource/input.go
+++ b/pkg/engine/datasource/introspection_datasource/input.go
@@ -33,7 +33,7 @@ var (
 	rBrace                 = []byte("}")
 	comma                  = []byte(",")
 	requestTypeField       = []byte(`"request_type":`)
-	onTypeField            = []byte(`"on_type_name":{{ .object.name }}`)
+	onTypeField            = []byte(`"on_type_name":"{{ .object.name }}"`)
 	typeNameField          = []byte(`"type_name":"{{ .arguments.name }}"`)
 	includeDeprecatedField = []byte(`"include_deprecated":{{ .arguments.includeDeprecated }}`)
 )

--- a/pkg/engine/datasource/introspection_datasource/input_test.go
+++ b/pkg/engine/datasource/introspection_datasource/input_test.go
@@ -19,8 +19,8 @@ func TestBuildInput(t *testing.T) {
 
 	t.Run("schema introspection", run(schemaFieldName, `{"request_type":1}`))
 	t.Run("type introspection", run(typeFieldName, `{"request_type":2,"type_name":"{{ .arguments.name }}"}`))
-	t.Run("type fields", run(fieldsFieldName, `{"request_type":3,"on_type_name":{{ .object.name }},"include_deprecated":{{ .arguments.includeDeprecated }}}`))
-	t.Run("type enum values", run(enumValuesFieldName, `{"request_type":4,"on_type_name":{{ .object.name }},"include_deprecated":{{ .arguments.includeDeprecated }}}`))
+	t.Run("type fields", run(fieldsFieldName, `{"request_type":3,"on_type_name":"{{ .object.name }}","include_deprecated":{{ .arguments.includeDeprecated }}}`))
+	t.Run("type enum values", run(enumValuesFieldName, `{"request_type":4,"on_type_name":"{{ .object.name }}","include_deprecated":{{ .arguments.includeDeprecated }}}`))
 }
 
 func TestUnmarshalIntrospectionInput(t *testing.T) {

--- a/pkg/engine/datasource/introspection_datasource/planner_test.go
+++ b/pkg/engine/datasource/introspection_datasource/planner_test.go
@@ -208,7 +208,7 @@ func TestIntrospectionDataSourcePlanning(t *testing.T) {
 									Fetches: []resolve.Fetch{
 										&resolve.SingleFetch{
 											BufferId:   1,
-											Input:      `{"request_type":3,"on_type_name":$$0$$,"include_deprecated":$$1$$}`,
+											Input:      `{"request_type":3,"on_type_name":"$$0$$","include_deprecated":$$1$$}`,
 											DataSource: &Source{},
 											Variables: resolve.NewVariables(
 												&resolve.ObjectVariable{
@@ -224,7 +224,7 @@ func TestIntrospectionDataSourcePlanning(t *testing.T) {
 										},
 										&resolve.SingleFetch{
 											BufferId:   2,
-											Input:      `{"request_type":4,"on_type_name":$$0$$,"include_deprecated":$$1$$}`,
+											Input:      `{"request_type":4,"on_type_name":"$$0$$","include_deprecated":$$1$$}`,
 											DataSource: &Source{},
 											Variables: resolve.NewVariables(
 												&resolve.ObjectVariable{

--- a/pkg/engine/resolve/inputtemplate.go
+++ b/pkg/engine/resolve/inputtemplate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/buger/jsonparser"
+
 	"github.com/jensneuse/graphql-go-tools/pkg/fastbuffer"
 	"github.com/jensneuse/graphql-go-tools/pkg/lexer/literal"
 )
@@ -59,7 +60,11 @@ func (i *InputTemplate) renderObjectVariable(ctx context.Context, variables []by
 		return nil
 	}
 	if valueType == jsonparser.String {
-		value = variables[offset-len(value)-2:offset]
+		value = variables[offset-len(value)-2 : offset]
+		switch segment.Renderer.GetKind() {
+		case VariableRendererKindPlain:
+			segment.Renderer.(*PlainVariableRenderer).rootValueType.Value = valueType
+		}
 	}
 	return segment.Renderer.RenderVariable(ctx, value, preparedInput)
 }
@@ -71,7 +76,7 @@ func (i *InputTemplate) renderContextVariable(ctx *Context, segment TemplateSegm
 		return nil
 	}
 	if valueType == jsonparser.String {
-		value = ctx.Variables[offset-len(value)-2:offset]
+		value = ctx.Variables[offset-len(value)-2 : offset]
 	}
 	return segment.Renderer.RenderVariable(ctx, value, preparedInput)
 }


### PR DESCRIPTION
This PR solves a problem with rendering object variables when the content is a string.
A test has been added in the `graphql` package.

**Problem**
When using object variable rendering strings are always being rendered with quotes, e.g. `{{ .object.name }}` => `"lucky"`

This behavior results in a problem when being used in a URL:
`https://petlibrary.fake/{{ .object.name }}` => `https://petlibrary.fake/"lucky"`